### PR TITLE
feat: import instead of require networks.json

### DIFF
--- a/src/ethr-did-resolver.js
+++ b/src/ethr-did-resolver.js
@@ -5,6 +5,7 @@ import BN from 'bn.js'
 import EthContract from 'ethjs-contract'
 import DidRegistryContract from '../contracts/ethr-did-registry.json'
 import { Buffer } from 'buffer'
+import networksJson from './networks.json'
 const REGISTRY = '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b'
 
 function bytes32toString (bytes32) {
@@ -199,7 +200,7 @@ function getResolver (conf = {}) {
 
   const networks = {
     mainnet: configureNetwork(conf),
-    ...configureNetworks(require('./networks.json')),
+    ...configureNetworks(networksJson),
     ...configureNetworks(conf.networks)
   }
 


### PR DESCRIPTION
This PR fixes https://github.com/decentralized-identity/ethr-did-resolver/issues/36.

Referencing the `networks.json` using `require` syntax allowed the tests to pass, but does not get picked up by `microbundle` during the build process.  It results in an error when this module is used as a dependency to resolve an ethr-did that specifies a network name in the identifier.  By using the `import` syntax instead, `microbundle` is able to correctly bundle the json data into the build output.