### PR TITLE
add ARTIS ERC1056 contract addresses to spec

### DIFF
--- a/doc/did-method-spec.md
+++ b/doc/did-method-spec.md
@@ -28,6 +28,8 @@ attributes such as "service endpoints" are required, we deployed ERC1056 smart c
 -   RSK:     `0xdca7ef03e98e0dc2b855be647c39abe984fcf21b`
 -   RSK Testnet:`0xdca7ef03e98e0dc2b855be647c39abe984fcf21b`
 -   Alastria Telsius:`0x05cc574b19a3c11308f761b3d7263bd8608bc532`
+-   ARTIS tau1:   `0xdca7ef03e98e0dc2b855be647c39abe984fcf21b`
+-   ARTIS sigma1: `0xdca7ef03e98e0dc2b855be647c39abe984fcf21b`
 
 Since each Ethereum transaction must be funded, there is a growing trend of on-chain transactions that are
 authenticated via an externally created signature and not by the actual transaction originator. This allows for


### PR DESCRIPTION
See:
https://explorer.tau1.artis.network/address/0xdCa7EF03e98e0DC2B855bE647C39ABe984fcF21B/contracts
https://explorer.sigma1.artis.network/address/0xdCa7EF03e98e0DC2B855bE647C39ABe984fcF21B/contracts

Is there a way to register `ethr-network` for a network? `artis_t1` and `artis_s1` in this case.

Should there be more changes to ethr-did-resolver?