### PR TITLE
fix: reverse events to have consistent order

### DIFF
--- a/src/ethr-did-resolver.js
+++ b/src/ethr-did-resolver.js
@@ -280,6 +280,7 @@ function getResolver(conf = {}) {
         toBlock: previousChange
       })
       const events = logDecoder(logs)
+      events.reverse()
       previousChange = undefined
       for (const event of events) {
         history.unshift(event)


### PR DESCRIPTION
- parsing through events from latest to earliest
- reverse events as json rpc returns one batch of events from earliest to latest
- see https://github.com/decentralized-identity/ethr-did-resolver/issues/86#issuecomment-699961595 for more details on the bug

Currently there is probably no failure/error as only events from one block are fetched. Even if there are multiple events in one block they'll most likely not interfere with each other.