### PR TITLE
fix: ignore query string when interpreting identifiers

### DIFF
--- a/src/__tests__/extended-id.test.ts
+++ b/src/__tests__/extended-id.test.ts
@@ -1,4 +1,4 @@
-import { identifierMatcher } from '../helpers'
+import { identifierMatcher, interpretIdentifier } from '../helpers'
 
 describe('pattern matcher', () => {
   const matcher = identifierMatcher
@@ -35,5 +35,90 @@ describe('pattern matcher', () => {
     it('hex strings of larger size', () => {
       expect(matcher.test('0x02b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71dbe9d369')).toBe(false)
     })
+  })
+})
+
+describe('interpretIdentifier', () => {
+  const pubKey = '0x02b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71'
+  const checksumAddress = '0xC662e6c5F91B9FcD22D7FcafC80Cf8b640aed247'
+
+  it('parses ethereumAddress', () => {
+    const { address, publicKey, network } = interpretIdentifier(checksumAddress.toLowerCase())
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toBeUndefined()
+    expect(network).toBeUndefined()
+  })
+  it('parses ethereumAddress with checksum', () => {
+    const { address, publicKey, network } = interpretIdentifier(checksumAddress)
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toBeUndefined()
+    expect(network).toBeUndefined()
+  })
+  it('parses did:ethr with address', () => {
+    const { address, publicKey, network } = interpretIdentifier(`did:ethr:${checksumAddress}`)
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toBeUndefined()
+    expect(network).toBeUndefined()
+  })
+  it('parses did:ethr with address and version', () => {
+    const { address, publicKey, network } = interpretIdentifier(`did:ethr:${checksumAddress}?versionId=42`)
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toBeUndefined()
+    expect(network).toBeUndefined()
+  })
+  it('parses did:ethr with address and network', () => {
+    const { address, publicKey, network } = interpretIdentifier(`did:ethr:0x1:${checksumAddress}`)
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toBeUndefined()
+    expect(network).toEqual('0x1')
+  })
+  it('parses did:ethr with address and sub-network', () => {
+    const { address, publicKey, network } = interpretIdentifier(`did:ethr:rsk:testnet:${checksumAddress}`)
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toBeUndefined()
+    expect(network).toEqual('rsk:testnet')
+  })
+  it('parses did:ethr with address and sub-network and version', () => {
+    const { address, publicKey, network } = interpretIdentifier(`did:ethr:rsk:testnet:${checksumAddress}?versionId=42`)
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toBeUndefined()
+    expect(network).toEqual('rsk:testnet')
+  })
+
+  it('parses publicKey', () => {
+    const { address, publicKey, network } = interpretIdentifier(pubKey)
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toEqual(pubKey)
+    expect(network).toBeUndefined()
+  })
+  it('parses did:ethr with publicKey', () => {
+    const { address, publicKey, network } = interpretIdentifier(`did:ethr:${pubKey}`)
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toEqual(pubKey)
+    expect(network).toBeUndefined()
+  })
+  it('parses did:ethr with publicKey and version', () => {
+    const { address, publicKey, network } = interpretIdentifier(`did:ethr:${pubKey}?versionId=42`)
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toEqual(pubKey)
+    expect(network).toBeUndefined()
+  })
+  it('parses did:ethr with publicKey and network', () => {
+    const { address, publicKey, network } = interpretIdentifier(`did:ethr:mainnet:${pubKey}`)
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toEqual(pubKey)
+    expect(network).toEqual('mainnet')
+  })
+  it('parses did:ethr with publicKey and sub-network', () => {
+    const { address, publicKey, network } = interpretIdentifier(`did:ethr:not:so:main:net:${pubKey}`)
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toEqual(pubKey)
+    expect(network).toEqual('not:so:main:net')
+  })
+  it('parses did:ethr with publicKey and sub-network', () => {
+    const { address, publicKey, network } = interpretIdentifier(`did:ethr:not:so:main:net:${pubKey}?versionId=42`)
+    expect(address).toEqual(checksumAddress)
+    expect(publicKey).toEqual(pubKey)
+    expect(network).toEqual('not:so:main:net')
   })
 })

--- a/src/__tests__/networks.integration.test.ts
+++ b/src/__tests__/networks.integration.test.ts
@@ -9,14 +9,46 @@ describe('ethrResolver (alt-chains)', () => {
   const { address } = interpretIdentifier(addr)
   const checksumAddr = address
 
-  describe('eth-testnets', () => {
-    it('resolves on ropsten when configured', () => {
+  describe('eth-networks', () => {
+    it('resolves on mainnet with versionId', async () => {
+      const resolver = new Resolver(getResolver({ infuraProjectId: '6b734e0b04454df8a6ce234023c04f26' }))
+      const result = await resolver.resolve('did:ethr:0x26bf14321004e770e7a8b080b7a526d8eed8b388?versionId=12090174')
+      expect(result).toEqual({
+        didDocumentMetadata: {
+          nextVersionId: '12090175',
+          nextUpdate: '2021-03-22T18:14:29.000Z',
+        },
+        didResolutionMetadata: {
+          contentType: 'application/did+ld+json',
+        },
+        didDocument: {
+          '@context': [
+            'https://www.w3.org/ns/did/v1',
+            'https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/lds-ecdsa-secp256k1-recovery2020-0.0.jsonld',
+          ],
+          id: 'did:ethr:0x26bf14321004e770e7a8b080b7a526d8eed8b388',
+          verificationMethod: [
+            {
+              id: 'did:ethr:0x26bf14321004e770e7a8b080b7a526d8eed8b388#controller',
+              type: 'EcdsaSecp256k1RecoveryMethod2020',
+              controller: 'did:ethr:0x26bf14321004e770e7a8b080b7a526d8eed8b388',
+              blockchainAccountId: '0x26bF14321004e770E7A8b080b7a526d8eed8b388@eip155:1',
+            },
+          ],
+          authentication: ['did:ethr:0x26bf14321004e770e7a8b080b7a526d8eed8b388#controller'],
+          assertionMethod: ['did:ethr:0x26bf14321004e770e7a8b080b7a526d8eed8b388#controller'],
+        },
+      })
+    })
+
+    it('resolves on ropsten when configured', async () => {
       const did = 'did:ethr:ropsten:' + addr
       const ethr = getResolver({
         networks: [{ name: 'ropsten', rpcUrl: 'https://ropsten.infura.io/v3/6b734e0b04454df8a6ce234023c04f26' }],
       })
       const resolver = new Resolver(ethr)
-      return expect(resolver.resolve(did)).resolves.toEqual({
+      const result = await resolver.resolve(did)
+      expect(result).toEqual({
         didDocumentMetadata: {},
         didResolutionMetadata: { contentType: 'application/did+ld+json' },
         didDocument: {
@@ -39,13 +71,14 @@ describe('ethrResolver (alt-chains)', () => {
       })
     })
 
-    it('resolves on rinkeby when configured', () => {
+    it('resolves on rinkeby when configured', async () => {
       const did = 'did:ethr:rinkeby:' + addr
       const ethr = getResolver({
         networks: [{ name: 'rinkeby', rpcUrl: 'https://rinkeby.infura.io/v3/6b734e0b04454df8a6ce234023c04f26' }],
       })
       const resolver = new Resolver(ethr)
-      return expect(resolver.resolve(did)).resolves.toEqual({
+      const result = await resolver.resolve(did)
+      expect(result).toEqual({
         didDocumentMetadata: {},
         didResolutionMetadata: { contentType: 'application/did+ld+json' },
         didDocument: {
@@ -68,13 +101,14 @@ describe('ethrResolver (alt-chains)', () => {
       })
     })
 
-    it('resolves on kovan when configured', () => {
+    it('resolves on kovan when configured', async () => {
       const did = 'did:ethr:kovan:' + addr
       const ethr = getResolver({
         networks: [{ name: 'kovan', rpcUrl: 'https://kovan.infura.io/v3/6b734e0b04454df8a6ce234023c04f26' }],
       })
       const resolver = new Resolver(ethr)
-      return expect(resolver.resolve(did)).resolves.toEqual({
+      const result = await resolver.resolve(did)
+      expect(result).toEqual({
         didDocumentMetadata: {},
         didResolutionMetadata: { contentType: 'application/did+ld+json' },
         didDocument: {
@@ -97,11 +131,12 @@ describe('ethrResolver (alt-chains)', () => {
       })
     })
 
-    it('resolves on rsk when configured', () => {
+    it('resolves on rsk when configured', async () => {
       const did = 'did:ethr:rsk:' + addr
       const ethr = getResolver({ networks: [{ name: 'rsk', rpcUrl: 'https://did.rsk.co:4444' }] })
       const resolver = new Resolver(ethr)
-      return expect(resolver.resolve(did)).resolves.toEqual({
+      const result = await resolver.resolve(did)
+      expect(result).toEqual({
         didDocumentMetadata: {},
         didResolutionMetadata: { contentType: 'application/did+ld+json' },
         didDocument: {
@@ -124,11 +159,12 @@ describe('ethrResolver (alt-chains)', () => {
       })
     })
 
-    it('resolves on rsk:testnet when configured', () => {
+    it('resolves on rsk:testnet when configured', async () => {
       const did = 'did:ethr:rsk:testnet:' + addr
       const ethr = getResolver({ networks: [{ name: 'rsk:testnet', rpcUrl: 'https://did.testnet.rsk.co:4444' }] })
       const resolver = new Resolver(ethr)
-      return expect(resolver.resolve(did)).resolves.toEqual({
+      const result = await resolver.resolve(did)
+      expect(result).toEqual({
         didDocumentMetadata: {},
         didResolutionMetadata: { contentType: 'application/did+ld+json' },
         didDocument: {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -95,6 +95,7 @@ export function interpretIdentifier(identifier: string): { address: string; publ
   let id = identifier
   let network = undefined
   if (id.startsWith('did:ethr')) {
+    id = id.split('?')[0]
     const components = id.split(':')
     id = components[components.length - 1]
     if (components.length >= 4) {


### PR DESCRIPTION
fixes #122

Most of the PR is adding extra tests, the actual change is [on this line](https://github.com/decentralized-identity/ethr-did-resolver/pull/123/files#r616669845)

Background:
`interpretIdentifier()` is a helper method that is supposed to split a string into components
In case one of the components is a public key, to also compute the address.
In case the string is a DID, it should try to extract the network identifier section of it as well, and discard any query string

