### PR TITLE
fix: remove 0x prefix from publicKeyHex

### DIFF
--- a/doc/did-method-spec.md
+++ b/doc/did-method-spec.md
@@ -186,7 +186,7 @@ looks like this:
       "id": "did:ethr:0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798#controllerKey",
       "type": "EcdsaSecp256k1VerificationKey2019",
       "controller": "did:ethr:0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
-      "publicKeyHex": "0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+      "publicKeyHex": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
     }
   ],
   "authentication": [

--- a/src/__tests__/networks.integration.test.ts
+++ b/src/__tests__/networks.integration.test.ts
@@ -212,7 +212,7 @@ describe('ethrResolver (alt-chains)', () => {
               id: `${did}#controllerKey`,
               type: 'EcdsaSecp256k1VerificationKey2019',
               controller: did,
-              publicKeyHex: '0x03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479',
+              publicKeyHex: '03fdd57adec3d438ea237fe46b33ee1e016eda6b585c3e27ea66686c2ea5358479',
             },
           ],
           authentication: [`${did}#controller`, `${did}#controllerKey`],

--- a/src/__tests__/resolver.test.ts
+++ b/src/__tests__/resolver.test.ts
@@ -73,8 +73,8 @@ describe('ethrResolver', () => {
 
     it('resolves document with publicKey identifier', async () => {
       expect.assertions(1)
-      const pubKey = '0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
-      const pubdid = `did:ethr:dev:${pubKey}`
+      const pubKey = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+      const pubdid = `did:ethr:dev:0x${pubKey}`
       await expect(didResolver.resolve(pubdid)).resolves.toEqual({
         didDocumentMetadata: {},
         didResolutionMetadata: { contentType: 'application/did+ld+json' },
@@ -136,8 +136,8 @@ describe('ethrResolver', () => {
 
     it('changing controller invalidates the publicKey as identifier', async () => {
       expect.assertions(3)
-      const pubKey = '0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
-      const pubdid = `did:ethr:dev:${pubKey}`
+      const pubKey = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+      const pubdid = `did:ethr:dev:0x${pubKey}`
       const { didDocument } = await didResolver.resolve(pubdid)
       expect(didDocument).toEqual({
         '@context': [

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -81,6 +81,10 @@ export const legacyAlgoMap: Record<string, string> = {
   X25519KeyAgreementKey2019: verificationMethodTypes.X25519KeyAgreementKey2019,
 }
 
+export function strip0x(input: string): string {
+  return input.startsWith('0x') ? input.slice(2) : input
+}
+
 export function bytes32toString(input: bytes32 | Uint8Array): string {
   const buff: Buffer = typeof input === 'string' ? Buffer.from(input.slice(2), 'hex') : Buffer.from(input)
   return buff.toString('utf8').replace(/\0+$/, '')

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -28,6 +28,7 @@ import {
   DIDOwnerChanged,
   knownNetworks,
   Errors,
+  strip0x,
 } from './helpers'
 import { logDecoder } from './logParser'
 import * as qs from 'querystring'
@@ -198,7 +199,7 @@ export class EthrDidResolver {
                   case null:
                   case undefined:
                   case 'hex':
-                    pk.publicKeyHex = currentEvent.value.slice(2)
+                    pk.publicKeyHex = strip0x(currentEvent.value)
                     break
                   case 'base64':
                     pk.publicKeyBase64 = Buffer.from(currentEvent.value.slice(2), 'hex').toString('base64')
@@ -210,7 +211,7 @@ export class EthrDidResolver {
                     pk.publicKeyPem = Buffer.from(currentEvent.value.slice(2), 'hex').toString()
                     break
                   default:
-                    pk.value = currentEvent.value
+                    pk.value = strip0x(currentEvent.value)
                 }
                 pks[eventIndex] = pk
                 if (match[4] === 'sigAuth') {
@@ -271,7 +272,7 @@ export class EthrDidResolver {
         id: `${did}#controllerKey`,
         type: verificationMethodTypes.EcdsaSecp256k1VerificationKey2019,
         controller: did,
-        publicKeyHex: controllerKey,
+        publicKeyHex: strip0x(controllerKey),
       })
       authentication.push(`${did}#controllerKey`)
     }
@@ -384,7 +385,8 @@ export class EthrDidResolver {
         didResolutionMetadata: { contentType: 'application/did+ld+json' },
         didDocument,
       }
-    } catch (e) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
       return {
         didResolutionMetadata: {
           error: Errors.notFound,


### PR DESCRIPTION
fixes #140

BREAKING CHANGE: some applications may expect a 0x prefix so this is a breaking change.