### PR TITLE
fix: revert aurora tweaks and use known deployments in config

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
     "@ethersproject/providers": "^5.6.8",
     "@ethersproject/transactions": "^5.6.2",
     "did-resolver": "^3.2.2",
-    "ethr-did-registry": "^0.0.3"
+    "ethr-did-registry": "^1.0.0"
   }
 }

--- a/src/__tests__/networks.integration.test.ts
+++ b/src/__tests__/networks.integration.test.ts
@@ -216,8 +216,8 @@ describe('ethrResolver (alt-chains)', () => {
       const doc = await resolver.resolve(did)
       return expect(doc).toEqual({
         didDocumentMetadata: {
-          updated: '2022-01-19T12:19:59Z',
-          versionId: '57702193',
+          updated: '2022-01-19T12:20:00Z',
+          versionId: '57702194',
         },
         didResolutionMetadata: { contentType: 'application/did+ld+json' },
         didDocument: {

--- a/src/__tests__/resolver.test.ts
+++ b/src/__tests__/resolver.test.ts
@@ -2,7 +2,7 @@ import { Contract, ContractFactory } from '@ethersproject/contracts'
 import { Resolvable, Resolver } from 'did-resolver'
 import { getResolver } from '../resolver'
 import { EthrDidController } from '../controller'
-import DidRegistryContract from 'ethr-did-registry'
+import { EthereumDIDRegistry } from 'ethr-did-registry'
 import { interpretIdentifier, stringToBytes32 } from '../helpers'
 import { createProvider, sleep, startMining, stopMining } from './testUtils'
 import { nullAddress } from '../helpers'
@@ -24,7 +24,7 @@ describe('ethrResolver', () => {
   const web3Provider = createProvider()
 
   beforeAll(async () => {
-    const factory = ContractFactory.fromSolidity(DidRegistryContract).connect(web3Provider.getSigner(0))
+    const factory = ContractFactory.fromSolidity(EthereumDIDRegistry).connect(web3Provider.getSigner(0))
 
     registryContract = await factory.deploy()
     registryContract = await registryContract.deployed()

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -96,11 +96,13 @@ function configureNetworks(conf: MultiProviderConfiguration): ConfiguredNetworks
 }
 
 /**
- * Generates a configuration that maps ethereum network names and chainIDs to the respective ERC1056 contracts deployed on them.
+ * Generates a configuration that maps ethereum network names and chainIDs to the respective ERC1056 contracts deployed
+ * on them.
  * @returns a record of ERC1056 `Contract` instances
  * @param conf configuration options for the resolver. An array of network details.
  * Each network entry should contain at least one of `name` or `chainId` AND one of `provider`, `web3`, or `rpcUrl`
- * For convenience, you can also specify an `infuraProjectId` which will create a mapping for all the networks supported by https://infura.io.
+ * For convenience, you can also specify an `infuraProjectId` which will create a mapping for all the networks
+ *   supported by https://infura.io.
  * @example ```js
  * [
  *   { name: 'development', registry: '0x9af37603e98e0dc2b855be647c39abe984fc2445', rpcUrl: 'http://127.0.0.1:8545/' },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,8 +1,16 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Contract, ContractFactory } from '@ethersproject/contracts'
-import { InfuraProvider, JsonRpcProvider, Provider } from '@ethersproject/providers'
-import DidRegistryContract from 'ethr-did-registry'
-import { DEFAULT_REGISTRY_ADDRESS, knownInfuraNetworks, knownNetworks } from './helpers'
+import { JsonRpcProvider, Provider } from '@ethersproject/providers'
+import { EthereumDIDRegistry, deployments, EthrDidRegistryDeployment } from 'ethr-did-registry'
+import { DEFAULT_REGISTRY_ADDRESS } from './helpers'
+
+const infuraNames: Record<string, string> = {
+  polygon: 'matic',
+  'polygon:test': 'maticmum',
+  aurora: 'aurora-mainnet',
+}
+
+const knownInfuraNames = ['mainnet', 'ropsten', 'rinkeby', 'goerli', 'kovan', 'aurora']
 
 /**
  * A configuration entry for an ethereum network
@@ -15,16 +23,11 @@ import { DEFAULT_REGISTRY_ADDRESS, knownInfuraNetworks, knownNetworks } from './
  * { name: 'rsk:testnet', chainId: '0x1f', rpcUrl: 'https://public-node.testnet.rsk.co' }
  * ```
  */
-export interface ProviderConfiguration {
-  name?: string
+export interface ProviderConfiguration extends Omit<EthrDidRegistryDeployment, 'chainId'> {
   provider?: Provider
-  rpcUrl?: string
-  registry?: string
   chainId?: string | number
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   web3?: any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [index: string]: any
 }
 
 export interface MultiProviderConfiguration extends ProviderConfiguration {
@@ -43,13 +46,16 @@ function configureNetworksWithInfura(projectId?: string): ConfiguredNetworks {
   if (!projectId) {
     return {}
   }
-  const networks: ProviderConfiguration[] = [
-    { name: 'mainnet', chainId: '0x1', provider: new InfuraProvider('homestead', projectId) },
-    { name: 'ropsten', chainId: '0x3', provider: new InfuraProvider('ropsten', projectId) },
-    { name: 'rinkeby', chainId: '0x4', provider: new InfuraProvider('rinkeby', projectId) },
-    { name: 'goerli', chainId: '0x5', provider: new InfuraProvider('goerli', projectId) },
-    { name: 'kovan', chainId: '0x2a', provider: new InfuraProvider('kovan', projectId) },
-  ]
+
+  const networks = knownInfuraNames.map((n) => {
+    const existingDeployment = deployments.find((d) => d.name === n)
+    if (existingDeployment && existingDeployment.name) {
+      const infuraName = infuraNames[existingDeployment.name] || existingDeployment.name
+      const rpcUrl = `https://${infuraName}.infura.io/v3/${projectId}`
+      return { ...existingDeployment, rpcUrl }
+    }
+  }).filter(conf => !!conf) as ProviderConfiguration[]
+
   return configureNetworks({ networks })
 }
 
@@ -57,15 +63,14 @@ export function getContractForNetwork(conf: ProviderConfiguration): Contract {
   let provider: Provider = conf.provider || conf.web3?.currentProvider
   if (!provider) {
     if (conf.rpcUrl) {
-      const chainIdRaw = conf.chainId ? conf.chainId : knownNetworks[conf.name || '']
+      const chainIdRaw = conf.chainId ? conf.chainId : deployments.find((d) => d.name === conf.name)?.chainId
       const chainId = chainIdRaw ? BigNumber.from(chainIdRaw).toNumber() : chainIdRaw
-      const networkName = knownInfuraNetworks[conf.name || ''] ? conf.name?.replace('mainnet', 'homestead') : 'any'
-      provider = new JsonRpcProvider(conf.rpcUrl, chainId || networkName)
+      provider = new JsonRpcProvider(conf.rpcUrl, chainId || 'any')
     } else {
-      throw new Error(`invalid_config: No web3 provider could be determined for network ${conf.name || conf.chainId}`)
+      throw new Error(`invalid_config: No web3 provider could be determined for network ${conf.name || conf.chainId}, ${JSON.stringify(conf)}`)
     }
   }
-  const contract: Contract = ContractFactory.fromSolidity(DidRegistryContract)
+  const contract: Contract = ContractFactory.fromSolidity(EthereumDIDRegistry)
     .attach(conf.registry || DEFAULT_REGISTRY_ADDRESS)
     .connect(provider)
   return contract
@@ -73,7 +78,7 @@ export function getContractForNetwork(conf: ProviderConfiguration): Contract {
 
 function configureNetwork(net: ProviderConfiguration): ConfiguredNetworks {
   const networks: ConfiguredNetworks = {}
-  const chainId = net.chainId || knownNetworks[net.name || '']
+  const chainId = net.chainId || deployments.find((d) => (net.name && (d.name === net.name || d.description === net.name)))?.chainId
   if (chainId) {
     if (net.name) {
       networks[net.name] = getContractForNetwork(net)

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -47,14 +47,16 @@ function configureNetworksWithInfura(projectId?: string): ConfiguredNetworks {
     return {}
   }
 
-  const networks = knownInfuraNames.map((n) => {
-    const existingDeployment = deployments.find((d) => d.name === n)
-    if (existingDeployment && existingDeployment.name) {
-      const infuraName = infuraNames[existingDeployment.name] || existingDeployment.name
-      const rpcUrl = `https://${infuraName}.infura.io/v3/${projectId}`
-      return { ...existingDeployment, rpcUrl }
-    }
-  }).filter(conf => !!conf) as ProviderConfiguration[]
+  const networks = knownInfuraNames
+    .map((n) => {
+      const existingDeployment = deployments.find((d) => d.name === n)
+      if (existingDeployment && existingDeployment.name) {
+        const infuraName = infuraNames[existingDeployment.name] || existingDeployment.name
+        const rpcUrl = `https://${infuraName}.infura.io/v3/${projectId}`
+        return { ...existingDeployment, rpcUrl }
+      }
+    })
+    .filter((conf) => !!conf) as ProviderConfiguration[]
 
   return configureNetworks({ networks })
 }
@@ -67,7 +69,7 @@ export function getContractForNetwork(conf: ProviderConfiguration): Contract {
       const chainId = chainIdRaw ? BigNumber.from(chainIdRaw).toNumber() : chainIdRaw
       provider = new JsonRpcProvider(conf.rpcUrl, chainId || 'any')
     } else {
-      throw new Error(`invalid_config: No web3 provider could be determined for network ${conf.name || conf.chainId}, ${JSON.stringify(conf)}`)
+      throw new Error(`invalid_config: No web3 provider could be determined for network ${conf.name || conf.chainId}`)
     }
   }
   const contract: Contract = ContractFactory.fromSolidity(EthereumDIDRegistry)
@@ -78,7 +80,8 @@ export function getContractForNetwork(conf: ProviderConfiguration): Contract {
 
 function configureNetwork(net: ProviderConfiguration): ConfiguredNetworks {
   const networks: ConfiguredNetworks = {}
-  const chainId = net.chainId || deployments.find((d) => (net.name && (d.name === net.name || d.description === net.name)))?.chainId
+  const chainId =
+    net.chainId || deployments.find((d) => net.name && (d.name === net.name || d.description === net.name))?.chainId
   if (chainId) {
     if (net.name) {
       networks[net.name] = getContractForNetwork(net)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -113,24 +113,6 @@ export function interpretIdentifier(identifier: string): { address: string; publ
   }
 }
 
-export const knownInfuraNetworks: Record<string, string> = {
-  mainnet: '0x1',
-  ropsten: '0x3',
-  rinkeby: '0x4',
-  goerli: '0x5',
-  kovan: '0x2a',
-}
-
-export const knownNetworks: Record<string, string> = {
-  ...knownInfuraNetworks,
-  rsk: '0x1e',
-  'rsk:testnet': '0x1f',
-  artis_t1: '0x03c401',
-  artis_s1: '0x03c301',
-  matic: '0x89',
-  maticmum: '0x13881',
-}
-
 export enum Errors {
   /**
    * The resolver has failed to construct the DID document.

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -88,14 +88,11 @@ export class EthrDidResolver {
     let previousChange: BigNumber | null = await this.previousChange(address, networkId, blockTag)
     while (previousChange) {
       const blockNumber = previousChange
-      // console.log(`gigel ${previousChange}`)
-      const fromBlock =
-        previousChange.toHexString() !== '0x00' ? previousChange.sub(1).toHexString() : previousChange.toHexString()
       const logs = await provider.getLogs({
         address: contract.address, // networks[networkId].registryAddress,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         topics: [null as any, `0x000000000000000000000000${address.slice(2)}`],
-        fromBlock,
+        fromBlock: previousChange.toHexString(),
         toBlock: previousChange.toHexString(),
       })
       const events: ERC1056Event[] = logDecoder(contract, logs)

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -26,7 +26,6 @@ import {
   identifierMatcher,
   nullAddress,
   DIDOwnerChanged,
-  knownNetworks,
   Errors,
   strip0x,
 } from './helpers'
@@ -79,7 +78,7 @@ export class EthrDidResolver {
   ): Promise<{ address: string; history: ERC1056Event[]; controllerKey?: string; chainId: number }> {
     const contract = this.contracts[networkId]
     const provider = contract.provider
-    const hexChainId = networkId.startsWith('0x') ? networkId : knownNetworks[networkId]
+    const hexChainId = networkId.startsWith('0x') ? networkId : undefined
     //TODO: this can be used to check if the configuration is ok
     const chainId = hexChainId ? BigNumber.from(hexChainId).toNumber() : (await provider.getNetwork()).chainId
     const history: ERC1056Event[] = []

--- a/src/third.party.types.d.ts
+++ b/src/third.party.types.d.ts
@@ -1,2 +1,0 @@
-declare module 'ganache-cli'
-declare module 'ethr-did-registry'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3793,10 +3793,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-ethr-did-registry@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/ethr-did-registry/-/ethr-did-registry-0.0.3.tgz#f363d2c73cb9572b57bd7a5c9c90c88485feceb5"
-  integrity sha512-4BPvMGkxAK9vTduCq6D5b8ZqjteD2cvDIPPriXP6nnmPhWKFSxypo+AFvyQ0omJGa0cGTR+dkdI/8jiF7U/qaw==
+ethr-did-registry@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ethr-did-registry/-/ethr-did-registry-1.0.0.tgz#9fc076c5dd06288d79d4682ad7dd9b05832e8661"
+  integrity sha512-9Gl3WcogECcdIjCjFbTKtmkz18VlQf50qE9iELnLIYVsEZo+hB38ApwOd83sYMGAjSs2c1dlzUI96H9kyvfl7w==
 
 eventemitter3@^4.0.4:
   version "4.0.7"


### PR DESCRIPTION
This PR contains 2 changes:

* revert the tweaks that were necessary on aurora. They are now EVM compatible so the tweaks are no longer necessary.
  * The integration test with aurora had to be updated to fit their new block history.
  * This also fixes the failing builds that we've been experiencing for a couple weeks
* use the known deployments array (from ethr-did-registry) in the configuration.