### PR TITLE
fix: update imports from ethr-did-registry and bump package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,13 @@
   "module": "./lib/index.module.js",
   "unpkg": "./lib/index.umd.js",
   "types": "./lib/index.d.ts",
-  "umd:main": "./lib/index.umd.js",
-  "exports": "./lib/index.modern.js",
+  "umd:main": "./lib/index.umd.js",  
+  "exports": {
+    ".": {
+      "require": "./lib/index.cjs",
+      "import": "./lib/index.modern.js"
+    }
+  },
   "typesVersions": {
     "*": { 
       "lib/index.d.ts": ["lib/index.d.ts"],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Resolve DID documents for ethereum addresses and public keys",
   "type": "module",
   "source": "src/index.ts",
-  "main": "lib/index.cjs",
+  "main": "./lib/index.cjs",
   "module": "./lib/index.module.js",
   "unpkg": "./lib/index.umd.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
   "description": "Resolve DID documents for ethereum addresses and public keys",
   "type": "module",
   "source": "src/index.ts",
-  "main": "./lib/index.cjs",
+  "main": "lib/index.cjs",
   "module": "./lib/index.module.js",
   "unpkg": "./lib/index.umd.js",
   "types": "./lib/index.d.ts",
   "umd:main": "./lib/index.umd.js",
-  "exports": {
-    ".": {
-      "require": "./lib/index.cjs",
-      "import": "./lib/index.module.js"
+  "exports": "./lib/index.modern.js",
+  "typesVersions": {
+    "*": { 
+      "lib/index.d.ts": ["lib/index.d.ts"],
+      "*": ["./lib/index.d.js"]
     }
   },
   "repository": {
@@ -99,6 +100,6 @@
     "@ethersproject/providers": "^5.6.8",
     "@ethersproject/transactions": "^5.6.2",
     "did-resolver": "^4.0.0",
-    "ethr-did-registry": "^1.0.0"
+    "ethr-did-registry": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "./lib/index.module.js",
   "unpkg": "./lib/index.umd.js",
   "types": "./lib/index.d.ts",
-  "umd:main": "./lib/index.umd.js",  
+  "umd:main": "./lib/index.umd.js",
   "exports": {
     ".": {
       "require": "./lib/index.cjs",
@@ -16,9 +16,13 @@
     }
   },
   "typesVersions": {
-    "*": { 
-      "lib/index.d.ts": ["lib/index.d.ts"],
-      "*": ["./lib/index.d.js"]
+    "*": {
+      "lib/index.d.ts": [
+        "lib/index.d.ts"
+      ],
+      "*": [
+        "./lib/index.d.js"
+      ]
     }
   },
   "repository": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,7 +1,9 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Contract, ContractFactory } from '@ethersproject/contracts'
 import { JsonRpcProvider, Provider } from '@ethersproject/providers'
-import { EthereumDIDRegistry, deployments, EthrDidRegistryDeployment } from 'ethr-did-registry'
+import ethrDidRegistry from "ethr-did-registry"
+const { deployments, EthereumDIDRegistry } = ethrDidRegistry;
+
 import { DEFAULT_REGISTRY_ADDRESS } from './helpers'
 
 const infuraNames: Record<string, string> = {
@@ -23,7 +25,7 @@ const knownInfuraNames = ['mainnet', 'ropsten', 'rinkeby', 'goerli', 'kovan', 'a
  * { name: 'rsk:testnet', chainId: '0x1f', rpcUrl: 'https://public-node.testnet.rsk.co' }
  * ```
  */
-export interface ProviderConfiguration extends Omit<EthrDidRegistryDeployment, 'chainId'> {
+export interface ProviderConfiguration extends Omit<ethrDidRegistry.EthrDidRegistryDeployment, 'chainId'> {
   provider?: Provider
   chainId?: string | number
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Contract, ContractFactory } from '@ethersproject/contracts'
 import { JsonRpcProvider, Provider } from '@ethersproject/providers'
-import ethrDidRegistry from "ethr-did-registry"
-const { deployments, EthereumDIDRegistry } = ethrDidRegistry;
+import ethrDidRegistry from 'ethr-did-registry'
+const { deployments, EthereumDIDRegistry } = ethrDidRegistry
 
 import { DEFAULT_REGISTRY_ADDRESS } from './helpers'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4815,10 +4815,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-ethr-did-registry@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ethr-did-registry/-/ethr-did-registry-1.0.0.tgz#9fc076c5dd06288d79d4682ad7dd9b05832e8661"
-  integrity sha512-9Gl3WcogECcdIjCjFbTKtmkz18VlQf50qE9iELnLIYVsEZo+hB38ApwOd83sYMGAjSs2c1dlzUI96H9kyvfl7w==
+ethr-did-registry@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ethr-did-registry/-/ethr-did-registry-1.0.1.tgz#de6e9b5adaaffa8f97cf1351c6c57fbc58c88b96"
+  integrity sha512-v80+PLzT6so4Zk8vxPT+vDgtO4QiN/50Xvz8Gxpj+D70Y+dGvFFEJ22pW3OzVuRGqQ9+7yRVz+v1mufFN6lxJw==
 
 eventemitter3@^4.0.4:
   version "4.0.7"


### PR DESCRIPTION
- bump `ethr-did-registry` package
- update import of `ethr-did-registry` in `configuration.js`. `ethr-did-resolver` is able to build and pass tests without this change, but when included in an ESM package, the import was causing issues. This change allows this package to be used in ESM packages correctly
- I'm not sure that this solution is ideal. It's possible that `ethr-did-registry` needs to be updated to export correctly, but I could not figure out how to do that.