### PR TITLE
fix: hex values getting wrongly encoded to utf8 for setAttributeSigned

### DIFF
--- a/src/__tests__/networks.integration.test.ts
+++ b/src/__tests__/networks.integration.test.ts
@@ -38,10 +38,10 @@ describe('ethrResolver (alt-chains)', () => {
       })
     })
 
-    it('resolves on ropsten when configured', async () => {
-      const did = 'did:ethr:ropsten:' + addr
+    it('resolves on goerli when configured', async () => {
+      const did = 'did:ethr:goerli:' + addr
       const ethr = getResolver({
-        networks: [{ name: 'ropsten', rpcUrl: 'https://ropsten.infura.io/v3/6b734e0b04454df8a6ce234023c04f26' }],
+        networks: [{ name: 'goerli', rpcUrl: 'https://goerli.infura.io/v3/6b734e0b04454df8a6ce234023c04f26' }],
       })
       const resolver = new Resolver(ethr)
       const result = await resolver.resolve(did)
@@ -56,61 +56,7 @@ describe('ethrResolver (alt-chains)', () => {
               id: `${did}#controller`,
               type: 'EcdsaSecp256k1RecoveryMethod2020',
               controller: did,
-              blockchainAccountId: `eip155:3:${checksumAddr}`,
-            },
-          ],
-          authentication: [`${did}#controller`],
-          assertionMethod: [`${did}#controller`],
-        },
-      })
-    })
-
-    it('resolves on rinkeby when configured', async () => {
-      const did = 'did:ethr:rinkeby:' + addr
-      const ethr = getResolver({
-        networks: [{ name: 'rinkeby', rpcUrl: 'https://rinkeby.infura.io/v3/6b734e0b04454df8a6ce234023c04f26' }],
-      })
-      const resolver = new Resolver(ethr)
-      const result = await resolver.resolve(did)
-      expect(result).toEqual({
-        didDocumentMetadata: {},
-        didResolutionMetadata: { contentType: 'application/did+ld+json' },
-        didDocument: {
-          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/secp256k1recovery-2020/v2'],
-          id: did,
-          verificationMethod: [
-            {
-              id: `${did}#controller`,
-              type: 'EcdsaSecp256k1RecoveryMethod2020',
-              controller: did,
-              blockchainAccountId: `eip155:4:${checksumAddr}`,
-            },
-          ],
-          authentication: [`${did}#controller`],
-          assertionMethod: [`${did}#controller`],
-        },
-      })
-    })
-
-    it('resolves on kovan when configured', async () => {
-      const did = 'did:ethr:kovan:' + addr
-      const ethr = getResolver({
-        networks: [{ name: 'kovan', rpcUrl: 'https://kovan.infura.io/v3/6b734e0b04454df8a6ce234023c04f26' }],
-      })
-      const resolver = new Resolver(ethr)
-      const result = await resolver.resolve(did)
-      expect(result).toEqual({
-        didDocumentMetadata: {},
-        didResolutionMetadata: { contentType: 'application/did+ld+json' },
-        didDocument: {
-          '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/secp256k1recovery-2020/v2'],
-          id: did,
-          verificationMethod: [
-            {
-              id: `${did}#controller`,
-              type: 'EcdsaSecp256k1RecoveryMethod2020',
-              controller: did,
-              blockchainAccountId: `eip155:42:${checksumAddr}`,
+              blockchainAccountId: `eip155:5:${checksumAddr}`,
             },
           ],
           authentication: [`${did}#controller`],

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -10,7 +10,7 @@ import {
   MetaSignature,
   stringToBytes32,
 } from './helpers'
-import { arrayify, concat, hexConcat, hexlify, zeroPad } from '@ethersproject/bytes'
+import { arrayify, concat, hexConcat, hexlify, isHexString, zeroPad } from '@ethersproject/bytes'
 import { keccak256 } from '@ethersproject/keccak256'
 import { formatBytes32String, toUtf8Bytes } from '@ethersproject/strings'
 
@@ -295,17 +295,15 @@ export class EthrDidController {
   async createSetAttributeHash(attrName: string, attrValue: string, exp: number) {
     const paddedNonce = await this.getPaddedNonceCompatibility(true)
 
+    // The incoming attribute value may be a hex encoded key, or an utf8 encoded string (like service endpoints)
+    const encodedValue = isHexString(attrValue) ? attrValue : toUtf8Bytes(attrValue)
+
     const dataToHash = hexConcat([
       MESSAGE_PREFIX,
       this.contract.address,
       paddedNonce,
       this.address,
-      concat([
-        toUtf8Bytes('setAttribute'),
-        formatBytes32String(attrName),
-        toUtf8Bytes(attrValue),
-        zeroPad(hexlify(exp), 32),
-      ]),
+      concat([toUtf8Bytes('setAttribute'), formatBytes32String(attrName), encodedValue, zeroPad(hexlify(exp), 32)]),
     ])
     return keccak256(dataToHash)
   }


### PR DESCRIPTION
While testing the implementation of signed methods from this resolver i noticed that function `createSetAttributeHash` always encodes the `attributeValue` to uft8. 

If the controller now tries to add another key to a did, this key in hex format is also encoded to utf8. This effectively breaks the ability to add hex values via the `setAttributeSigned` method as the contract now calculates a different hash. Leading to a tx failure.
