### PR TITLE
chore: remove static overrides for gas price & limit

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -89,8 +89,6 @@ export class EthrDidController {
   async changeOwner(newOwner: address, options: CallOverrides = {}): Promise<TransactionReceipt> {
     // console.log(`changing owner for ${oldOwner} on registry at ${registryContract.address}`)
     const overrides = {
-      gasLimit: 123456,
-      gasPrice: 1000000000,
       ...options,
     }
 
@@ -120,8 +118,6 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
-      gasLimit: 123456,
-      gasPrice: 1000000000,
       ...options,
     }
 
@@ -146,8 +142,6 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
-      gasLimit: 123456,
-      gasPrice: 1000000000,
       ...options,
     }
     const contract = await this.attachContract(overrides.from)
@@ -190,8 +184,6 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
-      gasLimit: 123456,
-      gasPrice: 1000000000,
       ...options,
     }
     const contract = await this.attachContract(overrides.from)
@@ -217,8 +209,6 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
-      gasLimit: 123456,
-      gasPrice: 1000000000,
       ...options,
     }
     delegateType = delegateType.startsWith('0x') ? delegateType : stringToBytes32(delegateType)
@@ -253,8 +243,6 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
-      gasLimit: 123456,
-      gasPrice: 1000000000,
       ...options,
     }
     delegateType = delegateType.startsWith('0x') ? delegateType : stringToBytes32(delegateType)
@@ -279,8 +267,6 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
-      gasLimit: 123456,
-      gasPrice: 1000000000,
       controller: undefined,
       ...options,
     }
@@ -316,8 +302,6 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
-      gasLimit: 123456,
-      gasPrice: 1000000000,
       controller: undefined,
       ...options,
     }
@@ -341,8 +325,6 @@ export class EthrDidController {
   async revokeAttribute(attrName: string, attrValue: string, options: CallOverrides = {}): Promise<TransactionReceipt> {
     // console.log(`revoking attribute ${attrName}(${attrValue}) for ${identity}`)
     const overrides = {
-      gasLimit: 123456,
-      gasPrice: 1000000000,
       ...options,
     }
     attrName = attrName.startsWith('0x') ? attrName : stringToBytes32(attrName)
@@ -391,8 +373,6 @@ export class EthrDidController {
   ): Promise<TransactionReceipt> {
     // console.log(`revoking attribute ${attrName}(${attrValue}) for ${identity}`)
     const overrides = {
-      gasLimit: 123456,
-      gasPrice: 1000000000,
       ...options,
     }
     attrName = attrName.startsWith('0x') ? attrName : stringToBytes32(attrName)

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -89,6 +89,7 @@ export class EthrDidController {
   async changeOwner(newOwner: address, options: CallOverrides = {}): Promise<TransactionReceipt> {
     // console.log(`changing owner for ${oldOwner} on registry at ${registryContract.address}`)
     const overrides = {
+      gasLimit: 123456,
       ...options,
     }
 
@@ -118,6 +119,7 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
+      gasLimit: 123456,
       ...options,
     }
 
@@ -142,6 +144,7 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
+      gasLimit: 123456,
       ...options,
     }
     const contract = await this.attachContract(overrides.from)
@@ -184,6 +187,7 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
+      gasLimit: 123456,
       ...options,
     }
     const contract = await this.attachContract(overrides.from)
@@ -209,6 +213,7 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
+      gasLimit: 123456,
       ...options,
     }
     delegateType = delegateType.startsWith('0x') ? delegateType : stringToBytes32(delegateType)
@@ -243,6 +248,7 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
+      gasLimit: 123456,
       ...options,
     }
     delegateType = delegateType.startsWith('0x') ? delegateType : stringToBytes32(delegateType)
@@ -267,6 +273,7 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
+      gasLimit: 123456,
       controller: undefined,
       ...options,
     }
@@ -302,6 +309,7 @@ export class EthrDidController {
     options: CallOverrides = {}
   ): Promise<TransactionReceipt> {
     const overrides = {
+      gasLimit: 123456,
       controller: undefined,
       ...options,
     }
@@ -325,6 +333,7 @@ export class EthrDidController {
   async revokeAttribute(attrName: string, attrValue: string, options: CallOverrides = {}): Promise<TransactionReceipt> {
     // console.log(`revoking attribute ${attrName}(${attrValue}) for ${identity}`)
     const overrides = {
+      gasLimit: 123456,
       ...options,
     }
     attrName = attrName.startsWith('0x') ? attrName : stringToBytes32(attrName)
@@ -373,6 +382,7 @@ export class EthrDidController {
   ): Promise<TransactionReceipt> {
     // console.log(`revoking attribute ${attrName}(${attrValue}) for ${identity}`)
     const overrides = {
+      gasLimit: 123456,
       ...options,
     }
     attrName = attrName.startsWith('0x') ? attrName : stringToBytes32(attrName)


### PR DESCRIPTION
We faced issues executing transactions, because they had weird gas parameters set. We found out that it is currently hardcoded. This PR re-enables ethers to automatically determine gas price & limit as it is the default behaviour if it's not set.