### PR TITLE
feat: track signing keys independently

### DIFF
--- a/src/__tests__/resolve.attribute.test.ts
+++ b/src/__tests__/resolve.attribute.test.ts
@@ -142,8 +142,7 @@ describe('attributes', () => {
           },
         ],
         authentication: [`${did}#controller`],
-        // This is a bug. Encryption keys should not be added to assertionMethod See #184
-        assertionMethod: [`${did}#controller`, `${did}#delegate-1`],
+        assertionMethod: [`${did}#controller`],
         keyAgreement: [`${did}#delegate-1`],
       })
     })

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,21 +1,22 @@
 import {
-  Signer,
-  Contract,
-  BlockTag,
-  JsonRpcProvider,
-  Provider,
-  TransactionReceipt,
-  getBytes,
-  concat,
-  toBeHex,
-  isHexString,
-  zeroPadValue,
-  toUtf8Bytes,
-  keccak256,
-  encodeBytes32String,
-  Overrides,
-  AddressLike,
   Addressable,
+  AddressLike,
+  BlockTag,
+  concat,
+  Contract,
+  encodeBytes32String,
+  getBytes,
+  hexlify,
+  isHexString,
+  JsonRpcProvider,
+  keccak256,
+  Overrides,
+  Provider,
+  Signer,
+  toBeHex,
+  toUtf8Bytes,
+  TransactionReceipt,
+  zeroPadValue,
 } from 'ethers'
 import { getContractForNetwork } from './configuration'
 import {
@@ -285,7 +286,7 @@ export class EthrDidController {
       ...options,
     }
     attrName = attrName.startsWith('0x') ? attrName : stringToBytes32(attrName)
-    attrValue = attrValue.startsWith('0x') ? attrValue : '0x' + Buffer.from(attrValue, 'utf-8').toString('hex')
+    attrValue = attrValue.startsWith('0x') ? attrValue : hexlify(toUtf8Bytes(attrValue))
     const contract = await this.attachContract(overrides.from ?? undefined)
     delete overrides.from
     const setAttrTx = await contract.setAttribute(this.address, attrName, attrValue, exp, overrides)
@@ -326,7 +327,7 @@ export class EthrDidController {
       ...options,
     }
     attrName = attrName.startsWith('0x') ? attrName : stringToBytes32(attrName)
-    attrValue = attrValue.startsWith('0x') ? attrValue : '0x' + Buffer.from(attrValue, 'utf-8').toString('hex')
+    attrValue = attrValue.startsWith('0x') ? attrValue : hexlify(toUtf8Bytes(attrValue))
     const contract = await this.attachContract(overrides.from ?? undefined)
     delete overrides.from
     const setAttrTx = await contract.setAttributeSigned(
@@ -349,7 +350,7 @@ export class EthrDidController {
       ...options,
     }
     attrName = attrName.startsWith('0x') ? attrName : stringToBytes32(attrName)
-    attrValue = attrValue.startsWith('0x') ? attrValue : '0x' + Buffer.from(attrValue, 'utf-8').toString('hex')
+    attrValue = attrValue.startsWith('0x') ? attrValue : hexlify(toUtf8Bytes(attrValue))
     const contract = await this.attachContract(overrides.from ?? undefined)
     delete overrides.from
     const revokeAttributeTX = await contract.revokeAttribute(this.address, attrName, attrValue, overrides)
@@ -398,7 +399,7 @@ export class EthrDidController {
       ...options,
     }
     attrName = attrName.startsWith('0x') ? attrName : stringToBytes32(attrName)
-    attrValue = attrValue.startsWith('0x') ? attrValue : '0x' + Buffer.from(attrValue, 'utf-8').toString('hex')
+    attrValue = attrValue.startsWith('0x') ? attrValue : hexlify(toUtf8Bytes(attrValue))
     const contract = await this.attachContract(overrides.from ?? undefined)
     delete overrides.from
     const revokeAttributeTX = await contract.revokeAttributeSigned(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,5 @@
 import { VerificationMethod } from 'did-resolver'
-import { computeAddress, getAddress } from 'ethers'
+import { computeAddress, getAddress, toUtf8Bytes, toUtf8String, zeroPadBytes } from 'ethers'
 
 export const identifierMatcher = /^(.*)?(0x[0-9a-fA-F]{40}|0x[0-9a-fA-F]{66})$/
 export const nullAddress = '0x0000000000000000000000000000000000000000'
@@ -95,13 +95,12 @@ export function strip0x(input: string): string {
 }
 
 export function bytes32toString(input: bytes32 | Uint8Array): string {
-  const buff: Buffer = typeof input === 'string' ? Buffer.from(input.slice(2), 'hex') : Buffer.from(input)
-  return buff.toString('utf8').replace(/\0+$/, '')
+  return toUtf8String(input).replace(/\0+$/, '')
 }
 
 export function stringToBytes32(str: string): string {
-  const buffStr = '0x' + Buffer.from(str).slice(0, 32).toString('hex')
-  return buffStr + '0'.repeat(66 - buffStr.length)
+  const bytes = toUtf8Bytes(str)
+  return zeroPadBytes(bytes.slice(0, 32), 32)
 }
 
 export function interpretIdentifier(identifier: string): { address: string; publicKey?: string; network?: string } {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,4 +1,4 @@
-import { BlockTag, encodeBase58 } from 'ethers'
+import { BlockTag, encodeBase58, encodeBase64, toUtf8String } from 'ethers'
 import { ConfigurationOptions, ConfiguredNetworks, configureResolverWithNetworks } from './configuration'
 import {
   DIDDocument,
@@ -197,13 +197,13 @@ export class EthrDidResolver {
                     pk.publicKeyHex = strip0x(currentEvent.value)
                     break
                   case 'base64':
-                    pk.publicKeyBase64 = Buffer.from(currentEvent.value.slice(2), 'hex').toString('base64')
+                    pk.publicKeyBase64 = encodeBase64(currentEvent.value)
                     break
                   case 'base58':
-                    pk.publicKeyBase58 = encodeBase58(Buffer.from(currentEvent.value.slice(2), 'hex'))
+                    pk.publicKeyBase58 = encodeBase58(currentEvent.value)
                     break
                   case 'pem':
-                    pk.publicKeyPem = Buffer.from(currentEvent.value.slice(2), 'hex').toString()
+                    pk.publicKeyPem = toUtf8String(currentEvent.value)
                     break
                   default:
                     pk.value = strip0x(currentEvent.value)
@@ -216,12 +216,13 @@ export class EthrDidResolver {
                 }
                 break
               }
-              case 'svc':
+              case 'svc': {
                 serviceCount++
+                const encodedService = toUtf8String(currentEvent.value)
                 try {
-                  endpoint = JSON.parse(Buffer.from(currentEvent.value.slice(2), 'hex').toString())
+                  endpoint = JSON.parse(encodedService)
                 } catch {
-                  endpoint = Buffer.from(currentEvent.value.slice(2), 'hex').toString()
+                  endpoint = encodedService
                 }
                 services[eventIndex] = {
                   id: `${did}#service-${serviceCount}`,
@@ -229,6 +230,7 @@ export class EthrDidResolver {
                   serviceEndpoint: endpoint,
                 }
                 break
+              }
             }
           }
         }


### PR DESCRIPTION
fixes #184

This is technically a breaking change, since the keys in the `verificationMethod` array are no longer all referenced in the `assertionMethod`.