### PR TITLE
feat: support additional key types in the reference resolver implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/node,linux,macos,windows,intellij
+
+dist/

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "EcdsaSecp256k1VerificationKey2019",
     "Ed25519VerificationKey2020",
     "X25519KeyAgreementKey2020",
-    "Multikey",
-    "Bls12381G2Key2020"
+    "Multikey"
   ],
   "scripts": {
     "test": "HARDHAT_CONFIG=hardhat.config.mts vitest run",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
     "EIP1056",
     "EcdsaSecp256k1RecoveryMethod2020",
     "EcdsaSecp256k1VerificationKey2019",
-    "Ed25519VerificationKey2018"
+    "Ed25519VerificationKey2020",
+    "X25519KeyAgreementKey2020",
+    "Multikey",
+    "Bls12381G2Key2020"
   ],
   "scripts": {
     "test": "HARDHAT_CONFIG=hardhat.config.mts vitest run",
@@ -72,7 +75,7 @@
     "vitest": "4.1.5"
   },
   "dependencies": {
-    "did-resolver": "^5.0.0",
+    "did-resolver": "^5.0.1",
     "ethers": "^6.8.1"
   },
   "packageManager": "pnpm@10.33.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       did-resolver:
-        specifier: ^5.0.0
+        specifier: ^5.0.1
         version: 5.0.1
       ethers:
         specifier: ^6.8.1

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -6,7 +6,7 @@ describe('configuration', () => {
   it('works with infuraProjectId', () => {
     const contracts = configureResolverWithNetworks({
       infuraProjectId: 'blabla',
-      networks: [{ name: 'dev', rpcUrl: 'test' }],
+      networks: [{ name: 'dev', rpcUrl: 'test', registry: '0x9af37603e98e0dc2b855be647c39abe984fc2445' }],
     })
     expect(contracts['mainnet']).toBeDefined()
     expect(contracts['0x1']).toBeDefined()
@@ -43,21 +43,23 @@ describe('configuration', () => {
 
   it('works with single provider', async () => {
     const contracts = configureResolverWithNetworks({
-      provider: new JsonRpcProvider('some rinkeby JSONRPC URL'),
+      provider: new JsonRpcProvider('some JSONRPC URL'),
+      registry: '0x9af37603e98e0dc2b855be647c39abe984fc2445',
     })
     expect(contracts['']).toBeDefined()
   })
 
   it('works with only rpcUrl', async () => {
     const contracts = configureResolverWithNetworks({
-      rpcUrl: 'some rinkeby JSONRPC URL',
+      rpcUrl: 'some JSONRPC URL',
+      registry: '0x9af37603e98e0dc2b855be647c39abe984fc2445',
     })
     expect(contracts['']).toBeDefined()
   })
 
   it('works with rpc and numbered chainId', async () => {
     const contracts = configureResolverWithNetworks({
-      rpcUrl: 'some rinkeby JSONRPC URL',
+      rpcUrl: 'some JSONRPC URL',
       chainId: BigInt(1),
     })
     expect(contracts['0x1']).toBeDefined()
@@ -67,6 +69,12 @@ describe('configuration', () => {
     expect(() => {
       configureResolverWithNetworks()
     }).toThrowError('invalid_config: Please make sure to have at least one network')
+  })
+
+  it('throws when no registry is known for a network', () => {
+    expect(() => {
+      configureResolverWithNetworks({ networks: [{ name: 'unknown-net', rpcUrl: 'http://localhost:8545' }] })
+    }).toThrowError('invalid_config: No registry address known for network unknown-net')
   })
 
   it('throws when no relevant configuration is provided for a network', () => {

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -198,18 +198,20 @@ describe('non-DID registry events', () => {
     expect(result.didDocument?.verificationMethod).toHaveLength(1)
   })
 
-  it('skips pem key when value bytes are not valid UTF-8', async () => {
+  it('encodes pem key from raw bytes regardless of UTF-8 validity', async () => {
     expect.assertions(3)
     const { address: identity, shortDID: did, signer } = await randomAccount(provider)
     const connected = registryContract.connect(signer) as Contract
-    const pemAttrName = stringToBytes32('did/pub/Secp256k1/veriKey/pem')
-    // value is raw bytes that are not valid UTF-8 (a PEM should be ASCII text)
+    // RSA always uses PEM output; arbitrary bytes are DER-wrapped in PEM headers
+    const pemAttrName = stringToBytes32('did/pub/RSA/veriKey/pem')
     await connected['setAttribute'](identity, pemAttrName, INVALID_UTF8_BYTES, 86400)
     const result = await didResolver.resolve(did)
     expect(result.didResolutionMetadata.error).toBeUndefined()
-    // The malformed pem key must NOT appear in the document
-    expect(result.didDocument?.verificationMethod).toHaveLength(1)
-    expect(result.didDocument?.assertionMethod).toHaveLength(1)
+    // Raw bytes are DER-encoded and wrapped in PEM headers regardless of UTF-8 validity
+    expect(result.didDocument?.verificationMethod).toHaveLength(2)
+    expect(result.didDocument?.verificationMethod?.[1]).toMatchObject({
+      publicKeyPem: '-----BEGIN PUBLIC KEY-----\ngIGCgw==\n-----END PUBLIC KEY-----',
+    })
   })
 
   it('skips service when value bytes are not valid UTF-8', async () => {

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -8,7 +8,7 @@ import { stringToBytes32 } from '../helpers'
 describe('error handling', () => {
   const didResolver = new Resolver(
     getResolver({
-      networks: [{ name: 'example', rpcUrl: 'example.com' }],
+      networks: [{ name: 'example', rpcUrl: 'example.com', registry: '0x9af37603e98e0dc2b855be647c39abe984fc2445' }],
     })
   )
 

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -198,22 +198,6 @@ describe('non-DID registry events', () => {
     expect(result.didDocument?.verificationMethod).toHaveLength(1)
   })
 
-  it('encodes pem key from raw bytes regardless of UTF-8 validity', async () => {
-    expect.assertions(3)
-    const { address: identity, shortDID: did, signer } = await randomAccount(provider)
-    const connected = registryContract.connect(signer) as Contract
-    // RSA always uses PEM output; arbitrary bytes are DER-wrapped in PEM headers
-    const pemAttrName = stringToBytes32('did/pub/RSA/veriKey/pem')
-    await connected['setAttribute'](identity, pemAttrName, INVALID_UTF8_BYTES, 86400)
-    const result = await didResolver.resolve(did)
-    expect(result.didResolutionMetadata.error).toBeUndefined()
-    // Raw bytes are DER-encoded and wrapped in PEM headers regardless of UTF-8 validity
-    expect(result.didDocument?.verificationMethod).toHaveLength(2)
-    expect(result.didDocument?.verificationMethod?.[1]).toMatchObject({
-      publicKeyPem: '-----BEGIN PUBLIC KEY-----\ngIGCgw==\n-----END PUBLIC KEY-----',
-    })
-  })
-
   it('skips service when value bytes are not valid UTF-8', async () => {
     expect.assertions(3)
     const { address: identity, shortDID: did, signer } = await randomAccount(provider)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2,8 +2,7 @@ import { test, expect } from 'vitest'
 import * as index from '../index'
 
 test('has export definitions', () => {
-  expect.assertions(6)
-  expect(index.REGISTRY).toBeDefined()
+  expect.assertions(5)
   expect(index.bytes32toString).toBeDefined()
   expect(index.getResolver).toBeDefined()
   expect(index.identifierMatcher).toBeDefined()

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2,11 +2,9 @@ import { test, expect } from 'vitest'
 import * as index from '../index'
 
 test('has export definitions', () => {
-  expect.assertions(8)
+  expect.assertions(6)
   expect(index.REGISTRY).toBeDefined()
-  expect(index.attrTypes).toBeDefined()
   expect(index.bytes32toString).toBeDefined()
-  expect(index.delegateTypes).toBeDefined()
   expect(index.getResolver).toBeDefined()
   expect(index.identifierMatcher).toBeDefined()
   expect(index.stringToBytes32).toBeDefined()

--- a/src/__tests__/networks.integration.test.ts
+++ b/src/__tests__/networks.integration.test.ts
@@ -251,7 +251,12 @@ describe('ethrResolver (alt-chains)', () => {
               id: `${did}#controllerKey`,
               type: 'EcdsaSecp256k1VerificationKey2019',
               controller: did,
-              publicKeyHex: '036d148205e34a8591dcdcea34fb7fed760f5f1eca66d254830833f755ff359ef0',
+              publicKeyJwk: {
+                kty: 'EC',
+                crv: 'secp256k1',
+                x: 'bRSCBeNKhZHc3Oo0-3_tdg9fHspm0lSDCDP3Vf81nvA',
+                y: 'S-wVJwCE67R8DVLJ209o7DxWvkC7zqA7WOMItOjkOKU',
+              },
             },
           ],
           authentication: [`${did}#controller`, `${did}#controllerKey`],

--- a/src/__tests__/resolve.attribute.test.ts
+++ b/src/__tests__/resolve.attribute.test.ts
@@ -104,7 +104,7 @@ describe('attributes', () => {
             id: `${did}#delegate-1`,
             type: 'EcdsaSecp256k1VerificationKey2019',
             controller: did,
-            publicKeyHex: pubKey.slice(2),
+            publicKeyJwk: expect.objectContaining({ kty: 'EC', crv: 'secp256k1' }),
           },
         ],
         authentication: [`${did}#controller`],
@@ -179,9 +179,11 @@ describe('attributes', () => {
     it('add RsaVerificationKey2018 signing key', async () => {
       expect.assertions(1)
       const { address: identity, shortDID: did, signer } = await randomAccount(provider)
+      // DER-encoded SubjectPublicKeyInfo (synthetic 1024-bit RSA key for testing)
+      const derHex = '30819f300d06092a864886f70d010101050003818d00308189028181' + '00' + 'bb'.repeat(128) + '0203010001'
       await new EthrDidController(identity, registryContract, signer).setAttribute(
         'did/pub/RSA/veriKey/pem',
-        '-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n',
+        `0x${derHex}`,
         86403
       )
       const { didDocument } = await didResolver.resolve(did)
@@ -199,7 +201,14 @@ describe('attributes', () => {
             id: `${did}#delegate-1`,
             type: 'RsaVerificationKey2018',
             controller: did,
-            publicKeyPem: '-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n',
+            publicKeyPem: [
+              '-----BEGIN PUBLIC KEY-----',
+              'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC7u7u7u7u7u7u7u7u7u7u7u7u7',
+              'u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7',
+              'u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7',
+              'u7u7u7u7u7u7u7u7uwIDAQAB',
+              '-----END PUBLIC KEY-----',
+            ].join('\n'),
           },
         ],
         authentication: [`${did}#controller`],
@@ -400,7 +409,7 @@ describe('attributes', () => {
             id: `${did}#delegate-1`,
             type: 'EcdsaSecp256k1VerificationKey2019',
             controller: did,
-            publicKeyHex: pubKey.slice(2),
+            publicKeyJwk: expect.objectContaining({ kty: 'EC', crv: 'secp256k1' }),
           },
         ],
         authentication: [`${did}#controller`],

--- a/src/__tests__/resolve.attribute.test.ts
+++ b/src/__tests__/resolve.attribute.test.ts
@@ -176,46 +176,6 @@ describe('attributes', () => {
       })
     })
 
-    it('add RsaVerificationKey2018 signing key', async () => {
-      expect.assertions(1)
-      const { address: identity, shortDID: did, signer } = await randomAccount(provider)
-      // DER-encoded SubjectPublicKeyInfo (synthetic 1024-bit RSA key for testing)
-      const derHex = '30819f300d06092a864886f70d010101050003818d00308189028181' + '00' + 'bb'.repeat(128) + '0203010001'
-      await new EthrDidController(identity, registryContract, signer).setAttribute(
-        'did/pub/RSA/veriKey/pem',
-        `0x${derHex}`,
-        86403
-      )
-      const { didDocument } = await didResolver.resolve(did)
-      expect(didDocument).toEqual({
-        '@context': expect.anything(),
-        id: did,
-        verificationMethod: [
-          {
-            id: `${did}#controller`,
-            type: 'EcdsaSecp256k1RecoveryMethod2020',
-            controller: did,
-            blockchainAccountId: `eip155:1337:${identity}`,
-          },
-          {
-            id: `${did}#delegate-1`,
-            type: 'RsaVerificationKey2018',
-            controller: did,
-            publicKeyPem: [
-              '-----BEGIN PUBLIC KEY-----',
-              'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC7u7u7u7u7u7u7u7u7u7u7u7u7',
-              'u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7',
-              'u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7',
-              'u7u7u7u7u7u7u7u7uwIDAQAB',
-              '-----END PUBLIC KEY-----',
-            ].join('\n'),
-          },
-        ],
-        authentication: [`${did}#controller`],
-        assertionMethod: [`${did}#controller`, `${did}#delegate-1`],
-      })
-    })
-
     it('add X25519KeyAgreementKey2020 encryption key', async () => {
       expect.assertions(1)
       const { address: identity, shortDID: did, signer } = await randomAccount(provider)

--- a/src/__tests__/resolve.attribute.test.ts
+++ b/src/__tests__/resolve.attribute.test.ts
@@ -112,13 +112,15 @@ describe('attributes', () => {
       })
     })
 
-    it('add Bls12381G2Key2020 assertion key', async () => {
+    it('add Bls12381G2Key2020 assertion key via Multikey', async () => {
       expect.assertions(1)
       const { address: identity, shortDID: did, signer } = await randomAccount(provider)
-      const pubKey = hexlify(toUtf8Bytes('public key material here')) // encodes to 0x7075626c6963206b6579206d6174657269616c2068657265 in base16
+      // 0xeb01 is the multicodec prefix for bls12_381-g2-pub; the on-chain value must include it
+      const rawKey = toUtf8Bytes('public key material here') // 0x7075626c6963206b6579206d6174657269616c2068657265
+      const pubKey = hexlify(new Uint8Array([0xeb, 0x01, ...rawKey]))
       await new EthrDidController(identity, registryContract, signer).setAttribute(
-        'did/pub/Bls12381G2Key2020', // attrName must fit into 32 bytes. Anything extra will be truncated.
-        pubKey, // There's no limit on the size of the public key material
+        'did/pub/Multikey', // attrName must fit into 32 bytes
+        pubKey,
         86401
       )
       const { didDocument } = await didResolver.resolve(did)
@@ -134,9 +136,9 @@ describe('attributes', () => {
           },
           {
             id: `${did}#delegate-1`,
-            type: 'Bls12381G2Key2020',
+            type: 'Multikey',
             controller: did,
-            publicKeyBase58: 'BFdJW3VPNkfWyTpjK8nrmijTp1RoLri9z',
+            publicKeyMultibase: 'z8CNhpjgEH67cHtG4PWA1dS9udD1Z4pKmUCVA',
           },
         ],
         authentication: [`${did}#controller`],

--- a/src/__tests__/resolve.attribute.test.ts
+++ b/src/__tests__/resolve.attribute.test.ts
@@ -3,7 +3,7 @@ import { BrowserProvider, Contract, ethers, hexlify, toUtf8Bytes } from 'ethers'
 import { Resolvable } from 'did-resolver'
 import { EthrDidController } from '../controller'
 import { deployRegistry, randomAccount, sleep } from './testUtils'
-import { stringToBytes32 } from '../helpers'
+import { stringToBytes32, toMultibase } from '../helpers'
 
 describe('attributes', () => {
   let registryContract: Contract, didResolver: Resolvable, provider: BrowserProvider
@@ -136,7 +136,7 @@ describe('attributes', () => {
             id: `${did}#delegate-1`,
             type: 'Bls12381G2Key2020',
             controller: did,
-            publicKeyHex: '7075626c6963206b6579206d6174657269616c2068657265',
+            publicKeyBase58: 'BFdJW3VPNkfWyTpjK8nrmijTp1RoLri9z',
           },
         ],
         authentication: [`${did}#controller`],
@@ -144,7 +144,7 @@ describe('attributes', () => {
       })
     })
 
-    it('add Ed25519VerificationKey2018 authentication key', async () => {
+    it('add Ed25519VerificationKey2020 authentication key', async () => {
       expect.assertions(1)
       const { address: identity, shortDID: did, signer } = await randomAccount(provider)
       const { pubKey } = await randomAccount(provider)
@@ -166,9 +166,9 @@ describe('attributes', () => {
           },
           {
             id: `${did}#delegate-1`,
-            type: 'Ed25519VerificationKey2018',
+            type: 'Ed25519VerificationKey2020',
             controller: did,
-            publicKeyBase64: ethers.encodeBase64(pubKey),
+            publicKeyMultibase: toMultibase(pubKey, new Uint8Array([0xed, 0x01])),
           },
         ],
         authentication: [`${did}#controller`, `${did}#delegate-1`],
@@ -176,7 +176,7 @@ describe('attributes', () => {
       })
     })
 
-    it('add RSAVerificationKey2018 signing key', async () => {
+    it('add RsaVerificationKey2018 signing key', async () => {
       expect.assertions(1)
       const { address: identity, shortDID: did, signer } = await randomAccount(provider)
       await new EthrDidController(identity, registryContract, signer).setAttribute(
@@ -197,7 +197,7 @@ describe('attributes', () => {
           },
           {
             id: `${did}#delegate-1`,
-            type: 'RSAVerificationKey2018',
+            type: 'RsaVerificationKey2018',
             controller: did,
             publicKeyPem: '-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n',
           },
@@ -207,13 +207,14 @@ describe('attributes', () => {
       })
     })
 
-    it('add X25519KeyAgreementKey2019 encryption key', async () => {
+    it('add X25519KeyAgreementKey2020 encryption key', async () => {
       expect.assertions(1)
       const { address: identity, shortDID: did, signer } = await randomAccount(provider)
       const pubKeyBase64 = 'MCowBQYDK2VuAyEAEYVXd3/7B4d0NxpSsA/tdVYdz5deYcR1U+ZkphdmEFI='
+      const pubKeyHex = ethers.hexlify(ethers.decodeBase64(pubKeyBase64))
       await new EthrDidController(did, registryContract, signer).setAttribute(
         'did/pub/X25519/enc/base64',
-        ethers.hexlify(ethers.decodeBase64(pubKeyBase64)),
+        pubKeyHex,
         86404
       )
       const { didDocument } = await didResolver.resolve(did)
@@ -229,9 +230,9 @@ describe('attributes', () => {
           },
           {
             id: `${did}#delegate-1`,
-            type: 'X25519KeyAgreementKey2019',
+            type: 'X25519KeyAgreementKey2020',
             controller: did,
-            publicKeyBase64: pubKeyBase64,
+            publicKeyMultibase: toMultibase(pubKeyHex, new Uint8Array([0xec, 0x01])),
           },
         ],
         authentication: [`${did}#controller`],
@@ -428,7 +429,7 @@ describe('attributes', () => {
       })
     })
 
-    it('revokes Ed25519VerificationKey2018 authentication key', async () => {
+    it('revokes Ed25519VerificationKey2020 authentication key', async () => {
       expect.assertions(2)
       const { address: identity, shortDID: did, signer } = await randomAccount(provider)
       const { pubKey } = await randomAccount(provider)
@@ -450,9 +451,9 @@ describe('attributes', () => {
           },
           {
             id: `${did}#delegate-1`,
-            type: 'Ed25519VerificationKey2018',
+            type: 'Ed25519VerificationKey2020',
             controller: did,
-            publicKeyBase64: ethers.encodeBase64(pubKey),
+            publicKeyMultibase: toMultibase(pubKey, new Uint8Array([0xed, 0x01])),
           },
         ],
         authentication: [`${did}#controller`, `${did}#delegate-1`],
@@ -555,9 +556,9 @@ describe('attributes', () => {
           },
           {
             id: `${did}#delegate-1`,
-            type: 'Ed25519VerificationKey2018',
+            type: 'Ed25519VerificationKey2020',
             controller: did,
-            publicKeyHex: pubKey.slice(2),
+            publicKeyMultibase: toMultibase(pubKey, new Uint8Array([0xed, 0x01])),
           },
         ],
         authentication: [`${did}#controller`, `${did}#delegate-1`],

--- a/src/__tests__/resolve.metatx.test.ts
+++ b/src/__tests__/resolve.metatx.test.ts
@@ -247,10 +247,10 @@ describe('meta transactions', () => {
       }
     )
     const result = await didResolver.resolve(identifier)
-    expect(result?.didDocument?.verificationMethod?.[1]).toEqual({
+    expect(result?.didDocument?.verificationMethod?.[1]).toMatchObject({
       controller: `${identifier}`,
       id: `${identifier}#delegate-1`,
-      publicKeyHex: attributeValue.slice(2),
+      publicKeyJwk: expect.objectContaining({ kty: 'EC', crv: 'secp256k1' }),
       type: 'EcdsaSecp256k1VerificationKey2019',
     })
   })

--- a/src/__tests__/resolve.unregistered.test.ts
+++ b/src/__tests__/resolve.unregistered.test.ts
@@ -3,6 +3,7 @@ import { BrowserProvider } from 'ethers'
 import { Resolvable } from 'did-resolver'
 
 import { deployRegistry, randomAccount } from './testUtils'
+import { compressedSecp256k1ToJwk } from '../helpers'
 
 describe('unregistered DIDs', () => {
   let didResolver: Resolvable, provider: BrowserProvider
@@ -57,7 +58,7 @@ describe('unregistered DIDs', () => {
             id: `${longDID}#controllerKey`,
             type: 'EcdsaSecp256k1VerificationKey2019',
             controller: longDID,
-            publicKeyHex: pubKey.slice(2),
+            publicKeyJwk: compressedSecp256k1ToJwk(pubKey),
           },
         ],
         authentication: [`${longDID}#controller`, `${longDID}#controllerKey`],
@@ -85,7 +86,7 @@ describe('unregistered DIDs', () => {
             id: `${pubdid}#controllerKey`,
             type: 'EcdsaSecp256k1VerificationKey2019',
             controller: pubdid,
-            publicKeyHex: pubKey.slice(2),
+            publicKeyJwk: compressedSecp256k1ToJwk(pubKey),
           },
         ],
         authentication: [`${pubdid}#controller`, `${pubdid}#controllerKey`],
@@ -113,7 +114,7 @@ describe('unregistered DIDs', () => {
             id: `${pubdid}#controllerKey`,
             type: 'EcdsaSecp256k1VerificationKey2019',
             controller: pubdid,
-            publicKeyHex: pubKey.slice(2),
+            publicKeyJwk: compressedSecp256k1ToJwk(pubKey),
           },
         ],
         authentication: [`${pubdid}#controller`, `${pubdid}#controllerKey`],
@@ -121,7 +122,8 @@ describe('unregistered DIDs', () => {
         '@context': [
           'https://www.w3.org/ns/did/v1',
           'https://w3id.org/security/suites/secp256k1recovery-2020/v2',
-          'https://w3id.org/security/v3-unstable',
+          'https://w3id.org/security/v2',
+          { publicKeyJwk: { '@id': 'https://w3id.org/security#publicKeyJwk', '@type': '@json' } },
         ],
       },
     })

--- a/src/__tests__/resolver.regression.test.ts
+++ b/src/__tests__/resolver.regression.test.ts
@@ -58,8 +58,8 @@ describe('regression', () => {
         {
           id: `${identifier}#delegate-1`,
           controller: identifier,
-          type: `Ed25519VerificationKey2018`,
-          publicKeyHex: authPubKey,
+          type: 'Ed25519VerificationKey2020',
+          publicKeyMultibase: 'z4xRFjeX6BuwkaJyoVa9Aby3PC9NzTf81gqqz1viRK469SVx4HoesPqYKwB',
         },
       ],
       authentication: [`${identifier}#controller`, `${identifier}#delegate-1`],
@@ -67,11 +67,10 @@ describe('regression', () => {
     })
   })
 
-  it('Ed25519VerificationKey2018 in base58 (https://github.com/decentralized-identity/ethr-did-resolver/pull/106)', async () => {
+  it('Ed25519VerificationKey2020 in base58 (https://github.com/decentralized-identity/ethr-did-resolver/pull/106)', async () => {
     expect.assertions(1)
     const { address, shortDID: identifier, signer } = await randomAccount(provider)
     const publicKeyHex = `b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71`
-    const expectedPublicKeyBase58 = 'DV4G2kpBKjE6zxKor7Cj21iL9x9qyXb6emqjszBXcuhz'
     await new EthrDidController(identifier, registryContract, signer).setAttribute(
       'did/pub/Ed25519/veriKey/base58',
       `0x${publicKeyHex}`,
@@ -90,9 +89,9 @@ describe('regression', () => {
         },
         {
           id: `${identifier}#delegate-1`,
-          type: 'Ed25519VerificationKey2018',
+          type: 'Ed25519VerificationKey2020',
           controller: identifier,
-          publicKeyBase58: expectedPublicKeyBase58,
+          publicKeyMultibase: 'z6MkrwKJd14cfGia7TAWXgAZs7GKyXRhPQqTLnkfiG9YY8VN',
         },
       ],
       authentication: [`${identifier}#controller`],

--- a/src/__tests__/resolver.versioning.test.ts
+++ b/src/__tests__/resolver.versioning.test.ts
@@ -130,9 +130,9 @@ describe('versioning', () => {
           },
           {
             id: `${identifier}#delegate-1`,
-            type: 'Ed25519VerificationKey2018',
+            type: 'Ed25519VerificationKey2020',
             controller: identifier,
-            publicKeyHex: '11111111',
+            publicKeyMultibase: 'z332EABvYQ',
           },
         ],
         authentication: [`${identifier}#controller`],

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,5 +1,4 @@
 import { Contract, ContractFactory, JsonRpcProvider, Provider } from 'ethers'
-import { DEFAULT_REGISTRY_ADDRESS } from './helpers.js'
 import { deployments, EthrDidRegistryDeployment } from './config/deployments.js'
 import { EthereumDIDRegistry } from './config/EthereumDIDRegistry.js'
 
@@ -71,9 +70,17 @@ export function getContractForNetwork(conf: ProviderConfiguration): Contract {
       throw new Error(`invalid_config: No web3 provider could be determined for network ${conf.name || conf.chainId}`)
     }
   }
-  const contract = ContractFactory.fromSolidity(EthereumDIDRegistry)
-    .attach(conf.registry || DEFAULT_REGISTRY_ADDRESS)
-    .connect(provider)
+  const registryAddress =
+    conf.registry ||
+    deployments.find(
+      (d) => (conf.chainId && BigInt(d.chainId) === BigInt(conf.chainId)) || (conf.name && d.name === conf.name)
+    )?.registry
+  if (!registryAddress) {
+    throw new Error(
+      `invalid_config: No registry address known for network ${conf.name || conf.chainId}. Please provide a registry address.`
+    )
+  }
+  const contract = ContractFactory.fromSolidity(EthereumDIDRegistry).attach(registryAddress).connect(provider)
   return contract as Contract
 }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -59,22 +59,25 @@ function configureNetworksWithInfura(projectId?: string): ConfiguredNetworks {
   return configureNetworks({ networks })
 }
 
+/** Returns true when a deployment matches the given conf by chainId or by name/description alias. */
+function matchesDeployment(d: (typeof deployments)[number], conf: ProviderConfiguration): boolean {
+  if (conf.chainId && BigInt(d.chainId) === BigInt(conf.chainId)) return true
+  if (conf.name && (d.name === conf.name || d.description === conf.name)) return true
+  return false
+}
+
 export function getContractForNetwork(conf: ProviderConfiguration): Contract {
   let provider: Provider = conf.provider || conf.web3?.currentProvider
   if (!provider) {
     if (conf.rpcUrl) {
-      const chainIdRaw = conf.chainId ? conf.chainId : deployments.find((d) => d.name === conf.name)?.chainId
+      const chainIdRaw = conf.chainId ? conf.chainId : deployments.find((d) => matchesDeployment(d, conf))?.chainId
       const chainId = chainIdRaw ? BigInt(chainIdRaw) : chainIdRaw
       provider = new JsonRpcProvider(conf.rpcUrl, chainId || 'any')
     } else {
       throw new Error(`invalid_config: No web3 provider could be determined for network ${conf.name || conf.chainId}`)
     }
   }
-  const registryAddress =
-    conf.registry ||
-    deployments.find(
-      (d) => (conf.chainId && BigInt(d.chainId) === BigInt(conf.chainId)) || (conf.name && d.name === conf.name)
-    )?.registry
+  const registryAddress = conf.registry || deployments.find((d) => matchesDeployment(d, conf))?.registry
   if (!registryAddress) {
     throw new Error(
       `invalid_config: No registry address known for network ${conf.name || conf.chainId}. Please provide a registry address.`
@@ -86,8 +89,7 @@ export function getContractForNetwork(conf: ProviderConfiguration): Contract {
 
 function configureNetwork(net: ProviderConfiguration): ConfiguredNetworks {
   const networks: ConfiguredNetworks = {}
-  const chainId =
-    net.chainId || deployments.find((d) => net.name && (d.name === net.name || d.description === net.name))?.chainId
+  const chainId = net.chainId || deployments.find((d) => matchesDeployment(d, net))?.chainId
   if (chainId) {
     if (net.name) {
       networks[net.name] = getContractForNetwork(net)

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -19,14 +19,7 @@ import {
   zeroPadValue,
 } from 'ethers'
 import { getContractForNetwork } from './configuration.js'
-import {
-  address,
-  DEFAULT_REGISTRY_ADDRESS,
-  interpretIdentifier,
-  MESSAGE_PREFIX,
-  MetaSignature,
-  stringToBytes32,
-} from './helpers.js'
+import { address, interpretIdentifier, MESSAGE_PREFIX, MetaSignature, stringToBytes32 } from './helpers.js'
 
 /**
  * A class that can be used to interact with the ERC1056 contract on behalf of a local controller key-pair
@@ -62,7 +55,7 @@ export class EthrDidController {
     chainNameOrId = 'mainnet',
     provider?: Provider,
     rpcUrl?: string,
-    registry: string = DEFAULT_REGISTRY_ADDRESS,
+    registry?: string,
     legacyNonce = true
   ) {
     this.legacyNonce = legacyNonce

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -43,8 +43,7 @@ export class EthrDidController {
    * @param provider - optional - a web3 Provider. At least one of `contract`, `provider`, or `rpcUrl` is required
    * @param rpcUrl - optional - a JSON-RPC URL that can be used to connect to an ethereum network. At least one of
    *   `contract`, `provider`, or `rpcUrl` is required
-   * @param registry - optional - The ERC1056 registry address. Defaults to
-   *   '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b'. Only used with 'provider' or 'rpcUrl'
+   * @param registry - optional - The ERC1056 registry address. Only used with 'provider' or 'rpcUrl'
    * @param legacyNonce - optional - If the legacy nonce tracking method should be accounted for. If lesser version of
    *   did-ethr-registry contract v1.0.0 is used then this should be true.
    */

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -49,8 +49,6 @@ export const VMTypes = {
   EcdsaSecp256k1RecoveryMethod2020: 'EcdsaSecp256k1RecoveryMethod2020',
   Ed25519VerificationKey2020: 'Ed25519VerificationKey2020',
   X25519KeyAgreementKey2020: 'X25519KeyAgreementKey2020',
-  Bls12381G2Key2020: 'Bls12381G2Key2020',
-  Bls12381G1Key2020: 'Bls12381G1Key2020',
   Multikey: 'Multikey',
 } as const
 export type VMTypes = (typeof VMTypes)[keyof typeof VMTypes]
@@ -87,8 +85,6 @@ export const algoToVMType: Record<string, string> = {
   Secp256k1: VMTypes.EcdsaSecp256k1VerificationKey2019,
   Ed25519: VMTypes.Ed25519VerificationKey2020,
   X25519: VMTypes.X25519KeyAgreementKey2020,
-  Bls12381G2: VMTypes.Bls12381G2Key2020,
-  Bls12381G1: VMTypes.Bls12381G1Key2020,
   Multikey: VMTypes.Multikey,
 }
 
@@ -169,8 +165,6 @@ export const multicodecPrefixes: Partial<Record<VMTypes, Uint8Array>> = {
   [VMTypes.Ed25519VerificationKey2020]: new Uint8Array([0xed, 0x01]), // ed25519-pub
   [VMTypes.X25519KeyAgreementKey2020]: new Uint8Array([0xec, 0x01]), // x25519-pub
   [VMTypes.EcdsaSecp256k1VerificationKey2019]: new Uint8Array([0xe7, 0x01]), // secp256k1-pub
-  [VMTypes.Bls12381G1Key2020]: new Uint8Array([0xea, 0x01]), // bls12_381-g1-pub
-  [VMTypes.Bls12381G2Key2020]: new Uint8Array([0xeb, 0x01]), // bls12_381-g2-pub
   // Multikey: prefix is already embedded in the on-chain value (e.g. 0x1200 for P-256)
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -182,8 +182,8 @@ export const multicodecPrefixes: Partial<Record<VMTypes, Uint8Array>> = {
  * already present in the on-chain value).
  */
 export function toMultibase(hexValue: string, prefix?: Uint8Array): string {
-  const raw = Buffer.from(strip0x(hexValue), 'hex')
-  const full = prefix ? Buffer.concat([prefix, raw]) : raw
+  const raw = getBytes(`0x${strip0x(hexValue)}`)
+  const full = prefix ? new Uint8Array([...prefix, ...raw]) : raw
   return 'z' + encodeBase58(full)
 }
 
@@ -193,9 +193,11 @@ export function toMultibase(hexValue: string, prefix?: Uint8Array): string {
  */
 export function compressedSecp256k1ToJwk(hex: string): Record<string, string> {
   const uncompressed = SigningKey.computePublicKey(hex.startsWith('0x') ? hex : `0x${hex}`, false)
-  // uncompressed is 0x04 || x (32 bytes) || y (32 bytes) → hex string of 130 chars (excluding 0x)
-  const raw = strip0x(uncompressed)
-  const x = Buffer.from(raw.slice(2, 66), 'hex').toString('base64url')
-  const y = Buffer.from(raw.slice(66, 130), 'hex').toString('base64url')
+  // uncompressed is 0x04 || x (32 bytes) || y (32 bytes)
+  const raw = getBytes(uncompressed)
+  const toBase64url = (bytes: Uint8Array) =>
+    encodeBase64(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  const x = toBase64url(raw.slice(1, 33))
+  const y = toBase64url(raw.slice(33, 65))
   return { kty: 'EC', crv: 'secp256k1', x, y }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { Extensible, VerificationMethod } from 'did-resolver'
+import { Extensible, JsonWebKey, VerificationMethod } from 'did-resolver'
 import {
   computeAddress,
   encodeBase58,
@@ -191,7 +191,7 @@ export function toMultibase(hexValue: string, prefix?: Uint8Array): string {
  * Decompresses a 33-byte secp256k1 public key (hex, with or without 0x prefix) and
  * returns a JWK object suitable for use as `publicKeyJwk` in a DID document.
  */
-export function compressedSecp256k1ToJwk(hex: string): Record<string, string> {
+export function compressedSecp256k1ToJwk(hex: string): JsonWebKey {
   const uncompressed = SigningKey.computePublicKey(hex.startsWith('0x') ? hex : `0x${hex}`, false)
   // uncompressed is 0x04 || x (32 bytes) || y (32 bytes)
   const raw = getBytes(uncompressed)
@@ -200,4 +200,23 @@ export function compressedSecp256k1ToJwk(hex: string): Record<string, string> {
   const x = toBase64url(raw.slice(1, 33))
   const y = toBase64url(raw.slice(33, 65))
   return { kty: 'EC', crv: 'secp256k1', x, y }
+}
+
+/**
+ * Decodes an on-chain hex value to a PEM public key string.
+ * If the bytes are valid UTF-8 and already contain a PEM header, returns them as-is.
+ * Otherwise treats the bytes as DER and wraps them in PEM headers.
+ */
+export function bytesToPem(hex: string): string {
+  const tryUtf8 = (() => {
+    try {
+      return toUtf8String(hex)
+    } catch {
+      return null
+    }
+  })()
+  if (tryUtf8?.includes('-----BEGIN')) return tryUtf8
+  const b64 = encodeBase64(getBytes(`0x${strip0x(hex)}`))
+  const lines = b64.match(/.{1,64}/g)?.join('\n') ?? b64
+  return `-----BEGIN PUBLIC KEY-----\n${lines}\n-----END PUBLIC KEY-----`
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -49,7 +49,6 @@ export const VMTypes = {
   EcdsaSecp256k1RecoveryMethod2020: 'EcdsaSecp256k1RecoveryMethod2020',
   Ed25519VerificationKey2020: 'Ed25519VerificationKey2020',
   X25519KeyAgreementKey2020: 'X25519KeyAgreementKey2020',
-  RsaVerificationKey2018: 'RsaVerificationKey2018',
   Bls12381G2Key2020: 'Bls12381G2Key2020',
   Bls12381G1Key2020: 'Bls12381G1Key2020',
   Multikey: 'Multikey',
@@ -88,7 +87,6 @@ export const algoToVMType: Record<string, string> = {
   Secp256k1: VMTypes.EcdsaSecp256k1VerificationKey2019,
   Ed25519: VMTypes.Ed25519VerificationKey2020,
   X25519: VMTypes.X25519KeyAgreementKey2020,
-  RSA: VMTypes.RsaVerificationKey2018,
   Bls12381G2: VMTypes.Bls12381G2Key2020,
   Bls12381G1: VMTypes.Bls12381G1Key2020,
   Multikey: VMTypes.Multikey,
@@ -173,7 +171,6 @@ export const multicodecPrefixes: Partial<Record<VMTypes, Uint8Array>> = {
   [VMTypes.EcdsaSecp256k1VerificationKey2019]: new Uint8Array([0xe7, 0x01]), // secp256k1-pub
   [VMTypes.Bls12381G1Key2020]: new Uint8Array([0xea, 0x01]), // bls12_381-g1-pub
   [VMTypes.Bls12381G2Key2020]: new Uint8Array([0xeb, 0x01]), // bls12_381-g2-pub
-  [VMTypes.RsaVerificationKey2018]: new Uint8Array([0x85, 0x24]), // rsa-pub
   // Multikey: prefix is already embedded in the on-chain value (e.g. 0x1200 for P-256)
 }
 
@@ -202,23 +199,4 @@ export function compressedSecp256k1ToJwk(hex: string): JsonWebKey {
   const x = toBase64url(raw.slice(1, 33))
   const y = toBase64url(raw.slice(33, 65))
   return { kty: 'EC', crv: 'secp256k1', x, y }
-}
-
-/**
- * Decodes an on-chain hex value to a PEM public key string.
- * If the bytes are valid UTF-8 and already contain a PEM header, returns them as-is.
- * Otherwise treats the bytes as DER and wraps them in PEM headers.
- */
-export function bytesToPem(hex: string): string {
-  const tryUtf8 = (() => {
-    try {
-      return toUtf8String(hex)
-    } catch {
-      return null
-    }
-  })()
-  if (tryUtf8?.includes('-----BEGIN')) return tryUtf8
-  const b64 = encodeBase64(getBytes(`0x${strip0x(hex)}`))
-  const lines = b64.match(/.{1,64}/g)?.join('\n') ?? b64
-  return `-----BEGIN PUBLIC KEY-----\n${lines}\n-----END PUBLIC KEY-----`
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -13,7 +13,6 @@ import {
 
 export const identifierMatcher = /^(.*)?(0x[0-9a-fA-F]{40}|0x[0-9a-fA-F]{66})$/
 export const nullAddress = '0x0000000000000000000000000000000000000000'
-export const DEFAULT_REGISTRY_ADDRESS = '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b'
 export const MESSAGE_PREFIX = '0x1900'
 
 export type address = string

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -39,9 +39,12 @@ export interface DIDDelegateChanged extends ERC1056Event {
 export enum verificationMethodTypes {
   EcdsaSecp256k1VerificationKey2019 = 'EcdsaSecp256k1VerificationKey2019',
   EcdsaSecp256k1RecoveryMethod2020 = 'EcdsaSecp256k1RecoveryMethod2020',
-  Ed25519VerificationKey2018 = 'Ed25519VerificationKey2018',
-  RSAVerificationKey2018 = 'RSAVerificationKey2018',
-  X25519KeyAgreementKey2019 = 'X25519KeyAgreementKey2019',
+  Ed25519VerificationKey2020 = 'Ed25519VerificationKey2020',
+  X25519KeyAgreementKey2020 = 'X25519KeyAgreementKey2020',
+  RsaVerificationKey2018 = 'RsaVerificationKey2018',
+  Bls12381G2Key2020 = 'Bls12381G2Key2020',
+  Bls12381G1Key2020 = 'Bls12381G1Key2020',
+  Multikey = 'Multikey',
 }
 
 export enum eventNames {
@@ -71,23 +74,22 @@ export interface MetaSignature {
   sigS: bytes32
 }
 
-export const legacyAttrTypes: Record<string, string> = {
-  sigAuth: 'SignatureAuthentication2018',
-  veriKey: 'VerificationKey2018',
-  enc: 'KeyAgreementKey2019',
-}
 
-export const legacyAlgoMap: Record<string, string> = {
-  /**@deprecated */
-  Secp256k1VerificationKey2018: verificationMethodTypes.EcdsaSecp256k1VerificationKey2019,
-  /**@deprecated */
-  Ed25519SignatureAuthentication2018: verificationMethodTypes.Ed25519VerificationKey2018,
-  /**@deprecated */
-  Secp256k1SignatureAuthentication2018: verificationMethodTypes.EcdsaSecp256k1VerificationKey2019,
-  //keep legacy mapping
-  RSAVerificationKey2018: verificationMethodTypes.RSAVerificationKey2018,
-  Ed25519VerificationKey2018: verificationMethodTypes.Ed25519VerificationKey2018,
-  X25519KeyAgreementKey2019: verificationMethodTypes.X25519KeyAgreementKey2019,
+/**
+ * Maps the `<key algorithm>` token from a `did/pub/<algorithm>/...` attribute name
+ * to the canonical verification method type for that algorithm.
+ *
+ * This is the primary lookup. If the algorithm is not found here the verbatim
+ * string `<algorithm>` is used.
+ */
+export const algoToVMType: Record<string, string> = {
+  Secp256k1: verificationMethodTypes.EcdsaSecp256k1VerificationKey2019,
+  Ed25519: verificationMethodTypes.Ed25519VerificationKey2020,
+  X25519: verificationMethodTypes.X25519KeyAgreementKey2020,
+  RSA: verificationMethodTypes.RsaVerificationKey2018,
+  Bls12381G2: verificationMethodTypes.Bls12381G2Key2020,
+  Bls12381G1: verificationMethodTypes.Bls12381G1Key2020,
+  Multikey: verificationMethodTypes.Multikey,
 }
 
 export function strip0x(input: string): string {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,10 +1,9 @@
 import { VerificationMethod } from 'did-resolver'
-import { computeAddress, getAddress, toUtf8Bytes, toUtf8String, zeroPadBytes } from 'ethers'
+import { computeAddress, encodeBase58, getAddress, SigningKey, toUtf8Bytes, toUtf8String, zeroPadBytes } from 'ethers'
 
 export const identifierMatcher = /^(.*)?(0x[0-9a-fA-F]{40}|0x[0-9a-fA-F]{66})$/
 export const nullAddress = '0x0000000000000000000000000000000000000000'
 export const DEFAULT_REGISTRY_ADDRESS = '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b'
-export const DEFAULT_JSON_RPC = 'http://127.0.0.1:8545/'
 export const MESSAGE_PREFIX = '0x1900'
 
 export type address = string
@@ -158,4 +157,39 @@ export enum Errors {
  */
 export function isDefined<T>(arg: T): arg is Exclude<T, null | undefined> {
   return arg !== null && typeof arg !== 'undefined'
+}
+
+/**
+ * Multicodec varint prefixes for known key types.
+ * Used to construct publicKeyMultibase values per the Multikey spec.
+ */
+export const multicodecPrefixes: Partial<Record<verificationMethodTypes, Uint8Array>> = {
+  [verificationMethodTypes.Ed25519VerificationKey2020]: new Uint8Array([0xed, 0x01]),
+  [verificationMethodTypes.X25519KeyAgreementKey2020]: new Uint8Array([0xec, 0x01]),
+  // Multikey values already carry their own prefix in the on-chain bytes
+}
+
+/**
+ * Encodes raw key bytes (hex string with or without 0x prefix) as a multibase base58btc string.
+ * If a multicodec prefix is provided it is prepended before encoding.
+ * If no prefix is provided the bytes are encoded as-is (for Multikey, where the prefix is
+ * already present in the on-chain value).
+ */
+export function toMultibase(hexValue: string, prefix?: Uint8Array): string {
+  const raw = Buffer.from(strip0x(hexValue), 'hex')
+  const full = prefix ? Buffer.concat([prefix, raw]) : raw
+  return 'z' + encodeBase58(full)
+}
+
+/**
+ * Decompresses a 33-byte secp256k1 public key (hex, with or without 0x prefix) and
+ * returns a JWK object suitable for use as `publicKeyJwk` in a DID document.
+ */
+export function compressedSecp256k1ToJwk(hex: string): Record<string, string> {
+  const uncompressed = SigningKey.computePublicKey(hex.startsWith('0x') ? hex : `0x${hex}`, false)
+  // uncompressed is 0x04 || x (32 bytes) || y (32 bytes) → hex string of 130 chars (excluding 0x)
+  const raw = strip0x(uncompressed)
+  const x = Buffer.from(raw.slice(2, 66), 'hex').toString('base64url')
+  const y = Buffer.from(raw.slice(66, 130), 'hex').toString('base64url')
+  return { kty: 'EC', crv: 'secp256k1', x, y }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -44,22 +44,24 @@ export interface DIDDelegateChanged extends ERC1056Event {
   validTo: uint256
 }
 
-export enum VMTypes {
-  EcdsaSecp256k1VerificationKey2019 = 'EcdsaSecp256k1VerificationKey2019',
-  EcdsaSecp256k1RecoveryMethod2020 = 'EcdsaSecp256k1RecoveryMethod2020',
-  Ed25519VerificationKey2020 = 'Ed25519VerificationKey2020',
-  X25519KeyAgreementKey2020 = 'X25519KeyAgreementKey2020',
-  RsaVerificationKey2018 = 'RsaVerificationKey2018',
-  Bls12381G2Key2020 = 'Bls12381G2Key2020',
-  Bls12381G1Key2020 = 'Bls12381G1Key2020',
-  Multikey = 'Multikey',
-}
+export const VMTypes = {
+  EcdsaSecp256k1VerificationKey2019: 'EcdsaSecp256k1VerificationKey2019',
+  EcdsaSecp256k1RecoveryMethod2020: 'EcdsaSecp256k1RecoveryMethod2020',
+  Ed25519VerificationKey2020: 'Ed25519VerificationKey2020',
+  X25519KeyAgreementKey2020: 'X25519KeyAgreementKey2020',
+  RsaVerificationKey2018: 'RsaVerificationKey2018',
+  Bls12381G2Key2020: 'Bls12381G2Key2020',
+  Bls12381G1Key2020: 'Bls12381G1Key2020',
+  Multikey: 'Multikey',
+} as const
+export type VMTypes = (typeof VMTypes)[keyof typeof VMTypes]
 
-export enum eventNames {
-  DIDOwnerChanged = 'DIDOwnerChanged',
-  DIDAttributeChanged = 'DIDAttributeChanged',
-  DIDDelegateChanged = 'DIDDelegateChanged',
-}
+export const eventNames = {
+  DIDOwnerChanged: 'DIDOwnerChanged',
+  DIDAttributeChanged: 'DIDAttributeChanged',
+  DIDDelegateChanged: 'DIDDelegateChanged',
+} as const
+export type eventNames = (typeof eventNames)[keyof typeof eventNames]
 
 /**
  * Verification Method definitions that allow extra properties
@@ -127,29 +129,30 @@ export function interpretIdentifier(identifier: string): { address: string; publ
   }
 }
 
-export enum Errors {
+export const Errors = {
   /**
    * The resolver has failed to construct the DID document.
    * This can be caused by a network issue, a wrong registry address or malformed logs while parsing the registry
    * history. Please inspect the `DIDResolutionMetadata.message` to debug further.
    */
-  notFound = 'notFound',
+  notFound: 'notFound',
 
   /**
    * The resolver does not know how to resolve the given DID. Most likely it is not a `did:ethr`.
    */
-  invalidDid = 'invalidDid',
+  invalidDid: 'invalidDid',
 
   /**
    * The resolver is misconfigured or is being asked to resolve a `DID` anchored on an unknown network
    */
-  unknownNetwork = 'unknownNetwork',
+  unknownNetwork: 'unknownNetwork',
 
   /**
    * The resolver does not support the 'accept' format requested with `DIDResolutionOptions`
    */
-  unsupportedFormat = 'unsupportedFormat',
-}
+  unsupportedFormat: 'unsupportedFormat',
+} as const
+export type Errors = (typeof Errors)[keyof typeof Errors]
 
 /**
  * Returns true when the argument is defined and not null.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,15 @@
-import { VerificationMethod } from 'did-resolver'
-import { computeAddress, encodeBase58, getAddress, SigningKey, toUtf8Bytes, toUtf8String, zeroPadBytes } from 'ethers'
+import { Extensible, VerificationMethod } from 'did-resolver'
+import {
+  computeAddress,
+  encodeBase58,
+  encodeBase64,
+  getBytes,
+  getAddress,
+  SigningKey,
+  toUtf8Bytes,
+  toUtf8String,
+  zeroPadBytes,
+} from 'ethers'
 
 export const identifierMatcher = /^(.*)?(0x[0-9a-fA-F]{40}|0x[0-9a-fA-F]{66})$/
 export const nullAddress = '0x0000000000000000000000000000000000000000'
@@ -35,7 +45,7 @@ export interface DIDDelegateChanged extends ERC1056Event {
   validTo: uint256
 }
 
-export enum verificationMethodTypes {
+export enum VMTypes {
   EcdsaSecp256k1VerificationKey2019 = 'EcdsaSecp256k1VerificationKey2019',
   EcdsaSecp256k1RecoveryMethod2020 = 'EcdsaSecp256k1RecoveryMethod2020',
   Ed25519VerificationKey2020 = 'Ed25519VerificationKey2020',
@@ -52,17 +62,10 @@ export enum eventNames {
   DIDDelegateChanged = 'DIDDelegateChanged',
 }
 
-export interface LegacyVerificationMethod extends VerificationMethod {
-  /**@deprecated */
-  publicKeyHex?: string
-  /**@deprecated */
-  publicKeyBase64?: string
-  /**@deprecated */
-  publicKeyPem?: string
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [x: string]: any
-}
+/**
+ * Verification Method definitions that allow extra properties
+ */
+export type ExtendedVerificationMethod = VerificationMethod & Extensible
 
 /**
  * Interface for transporting v, r, s signature parameters used in meta transactions
@@ -73,7 +76,6 @@ export interface MetaSignature {
   sigS: bytes32
 }
 
-
 /**
  * Maps the `<key algorithm>` token from a `did/pub/<algorithm>/...` attribute name
  * to the canonical verification method type for that algorithm.
@@ -82,13 +84,13 @@ export interface MetaSignature {
  * string `<algorithm>` is used.
  */
 export const algoToVMType: Record<string, string> = {
-  Secp256k1: verificationMethodTypes.EcdsaSecp256k1VerificationKey2019,
-  Ed25519: verificationMethodTypes.Ed25519VerificationKey2020,
-  X25519: verificationMethodTypes.X25519KeyAgreementKey2020,
-  RSA: verificationMethodTypes.RsaVerificationKey2018,
-  Bls12381G2: verificationMethodTypes.Bls12381G2Key2020,
-  Bls12381G1: verificationMethodTypes.Bls12381G1Key2020,
-  Multikey: verificationMethodTypes.Multikey,
+  Secp256k1: VMTypes.EcdsaSecp256k1VerificationKey2019,
+  Ed25519: VMTypes.Ed25519VerificationKey2020,
+  X25519: VMTypes.X25519KeyAgreementKey2020,
+  RSA: VMTypes.RsaVerificationKey2018,
+  Bls12381G2: VMTypes.Bls12381G2Key2020,
+  Bls12381G1: VMTypes.Bls12381G1Key2020,
+  Multikey: VMTypes.Multikey,
 }
 
 export function strip0x(input: string): string {
@@ -163,10 +165,14 @@ export function isDefined<T>(arg: T): arg is Exclude<T, null | undefined> {
  * Multicodec varint prefixes for known key types.
  * Used to construct publicKeyMultibase values per the Multikey spec.
  */
-export const multicodecPrefixes: Partial<Record<verificationMethodTypes, Uint8Array>> = {
-  [verificationMethodTypes.Ed25519VerificationKey2020]: new Uint8Array([0xed, 0x01]),
-  [verificationMethodTypes.X25519KeyAgreementKey2020]: new Uint8Array([0xec, 0x01]),
-  // Multikey values already carry their own prefix in the on-chain bytes
+export const multicodecPrefixes: Partial<Record<VMTypes, Uint8Array>> = {
+  [VMTypes.Ed25519VerificationKey2020]: new Uint8Array([0xed, 0x01]), // ed25519-pub
+  [VMTypes.X25519KeyAgreementKey2020]: new Uint8Array([0xec, 0x01]), // x25519-pub
+  [VMTypes.EcdsaSecp256k1VerificationKey2019]: new Uint8Array([0xe7, 0x01]), // secp256k1-pub
+  [VMTypes.Bls12381G1Key2020]: new Uint8Array([0xea, 0x01]), // bls12_381-g1-pub
+  [VMTypes.Bls12381G2Key2020]: new Uint8Array([0xeb, 0x01]), // bls12_381-g2-pub
+  [VMTypes.RsaVerificationKey2018]: new Uint8Array([0x85, 0x24]), // rsa-pub
+  // Multikey: prefix is already embedded in the on-chain value (e.g. 0x1200 for P-256)
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import { getResolver } from './resolver.js'
 import { EthrDidController } from './controller.js'
 import {
   bytes32toString,
-  DEFAULT_REGISTRY_ADDRESS,
   Errors,
   identifierMatcher,
   interpretIdentifier,
@@ -15,7 +14,6 @@ import { EthereumDIDRegistry } from './config/EthereumDIDRegistry.js'
 import { deployments, EthrDidRegistryDeployment } from './config/deployments.js'
 
 export {
-  DEFAULT_REGISTRY_ADDRESS as REGISTRY,
   getResolver,
   bytes32toString,
   stringToBytes32,
@@ -36,7 +34,6 @@ export {
 // This pattern seems to confuse some bundlers, causing errors like `Cannot read 'getResolver' of undefined`
 // see https://github.com/decentralized-identity/ethr-did-resolver/issues/186
 export default {
-  REGISTRY: DEFAULT_REGISTRY_ADDRESS,
   getResolver,
   bytes32toString,
   stringToBytes32,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,6 @@ import {
   Errors,
   identifierMatcher,
   interpretIdentifier,
-  legacyAlgoMap,
-  legacyAttrTypes,
   stringToBytes32,
   verificationMethodTypes,
   MetaSignature,
@@ -22,10 +20,6 @@ export {
   bytes32toString,
   stringToBytes32,
   EthrDidController,
-  /**@deprecated */
-  legacyAlgoMap as delegateTypes,
-  /**@deprecated */
-  legacyAttrTypes as attrTypes,
   verificationMethodTypes,
   identifierMatcher,
   interpretIdentifier,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
   identifierMatcher,
   interpretIdentifier,
   stringToBytes32,
-  verificationMethodTypes,
+  VMTypes,
   MetaSignature,
 } from './helpers.js'
 
@@ -20,7 +20,7 @@ export {
   bytes32toString,
   stringToBytes32,
   EthrDidController,
-  verificationMethodTypes,
+  VMTypes as verificationMethodTypes,
   identifierMatcher,
   interpretIdentifier,
   Errors,
@@ -41,7 +41,7 @@ export default {
   bytes32toString,
   stringToBytes32,
   EthrDidController,
-  verificationMethodTypes,
+  verificationMethodTypes: VMTypes,
   identifierMatcher,
   interpretIdentifier,
   Errors,

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -27,7 +27,6 @@ import {
   strip0x,
   toMultibase,
   compressedSecp256k1ToJwk,
-  bytesToPem,
   VMTypes,
 } from './helpers.js'
 import { logDecoder } from './logParser.js'
@@ -54,17 +53,11 @@ function buildLdContext(didDocument: DIDDocument): ContextEntry[] {
   const hasPublicKeyHex = allVMs.some((vm) => 'publicKeyHex' in vm)
   const hasPublicKeyJwk = allVMs.some((vm) => 'publicKeyJwk' in vm)
   const hasPublicKeyBase58 = allVMs.some((vm) => 'publicKeyBase58' in vm)
-  const hasPublicKeyPem = allVMs.some((vm) => 'publicKeyPem' in vm)
   const hasPublicKeyBase64 = allVMs.some((vm) => 'publicKeyBase64' in vm)
 
-  // security/v2 defines EcdsaSecp256k1VerificationKey2019, RsaVerificationKey2018,
-  // publicKeyBase58, publicKeyPem — add it when any of those types or properties are present.
-  if (
-    types.has(VMTypes.EcdsaSecp256k1VerificationKey2019) ||
-    types.has(VMTypes.RsaVerificationKey2018) ||
-    hasPublicKeyBase58 ||
-    hasPublicKeyPem
-  ) {
+  // security/v2 defines EcdsaSecp256k1VerificationKey2019,
+  // publicKeyBase58 — add it when any of those types or properties are present.
+  if (types.has(VMTypes.EcdsaSecp256k1VerificationKey2019) || hasPublicKeyBase58) {
     contexts.push('https://w3id.org/security/v2')
   }
 
@@ -93,12 +86,9 @@ function buildLdContext(didDocument: DIDDocument): ContextEntry[] {
   if (hasPublicKeyJwk) {
     inline['publicKeyJwk'] = { '@id': 'https://w3id.org/security#publicKeyJwk', '@type': '@json' }
   }
-  // publicKeyBase58/publicKeyPem are defined by security/v2; only add inline if that context is absent.
+  // publicKeyBase58 is defined by security/v2; only add inline if that context is absent.
   if (hasPublicKeyBase58 && !securityV2Included) {
     inline['publicKeyBase58'] = 'https://w3id.org/security#publicKeyBase58'
-  }
-  if (hasPublicKeyPem && !securityV2Included) {
-    inline['publicKeyPem'] = 'https://w3id.org/security#publicKeyPem'
   }
   // publicKeyBase64 is not defined by any suite context — always inline when present.
   if (hasPublicKeyBase64) {
@@ -298,11 +288,6 @@ export class EthrDidResolver {
                     // On-chain value already includes the multicodec prefix; just base58btc-encode.
                     pk.publicKeyMultibase = toMultibase(currentEvent.value)
                     break
-                  case VMTypes.RsaVerificationKey2018:
-                    // Encoding hint is ignored for RSA — always emit publicKeyPem,
-                    // consistent with how other known key types use their canonical encoding.
-                    pk.publicKeyPem = bytesToPem(currentEvent.value)
-                    break
                   default:
                     // Unknown key types: honor the encoding hint for legacy compat.
                     switch (encoding) {
@@ -316,9 +301,6 @@ export class EthrDidResolver {
                         break
                       case 'base58':
                         pk.publicKeyBase58 = encodeBase58(currentEvent.value)
-                        break
-                      case 'pem':
-                        pk.publicKeyPem = bytesToPem(currentEvent.value)
                         break
                       default:
                         pk.value = strip0x(currentEvent.value)

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -27,6 +27,7 @@ import {
   strip0x,
   toMultibase,
   compressedSecp256k1ToJwk,
+  bytesToPem,
   VMTypes,
 } from './helpers.js'
 import { logDecoder } from './logParser.js'
@@ -260,10 +261,13 @@ export class EthrDidResolver {
                 }
                 let keyDataSet = true
                 switch (pk.type) {
+                  case VMTypes.EcdsaSecp256k1VerificationKey2019:
+                    // Spec mandates publicKeyJwk for Secp256k1 attribute keys regardless of encoding hint.
+                    pk.publicKeyJwk = compressedSecp256k1ToJwk(currentEvent.value)
+                    break
                   case VMTypes.Ed25519VerificationKey2020:
                   case VMTypes.X25519KeyAgreementKey2020:
                     // Always produce publicKeyMultibase regardless of encoding hint, to match spec.
-                    // On-chain value is always raw key bytes (hex); prepend multicodec prefix.
                     pk.publicKeyMultibase = toMultibase(currentEvent.value, multicodecPrefixes[pk.type])
                     break
                   case VMTypes.Bls12381G2Key2020:
@@ -278,12 +282,7 @@ export class EthrDidResolver {
                   case VMTypes.RsaVerificationKey2018:
                     // RSA keys must be PEM-encoded UTF-8. Any other encoding hint is invalid.
                     if (encoding === 'pem' || encoding === null || encoding === undefined) {
-                      try {
-                        // TODO: this is wrong. The spec example says the raw bytes are DER and need to be b64 encoded and then pre/post fixed to be PEM
-                        pk.publicKeyPem = toUtf8String(currentEvent.value)
-                      } catch {
-                        keyDataSet = false
-                      }
+                      pk.publicKeyPem = bytesToPem(currentEvent.value)
                     } else {
                       keyDataSet = false
                     }
@@ -303,11 +302,7 @@ export class EthrDidResolver {
                         pk.publicKeyBase58 = encodeBase58(currentEvent.value)
                         break
                       case 'pem':
-                        try {
-                          pk.publicKeyPem = toUtf8String(currentEvent.value)
-                        } catch {
-                          keyDataSet = false
-                        }
+                        pk.publicKeyPem = bytesToPem(currentEvent.value)
                         break
                       default:
                         pk.value = strip0x(currentEvent.value)

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,4 +1,4 @@
-import { BlockTag, encodeBase58, encodeBase64, toUtf8String } from 'ethers'
+import { BlockTag, encodeBase58, encodeBase64, getBytes, toUtf8String } from 'ethers'
 import { ConfigurationOptions, ConfiguredNetworks, configureResolverWithNetworks } from './configuration.js'
 import type {
   ContextEntry,
@@ -21,13 +21,13 @@ import {
   identifierMatcher,
   interpretIdentifier,
   algoToVMType,
-  LegacyVerificationMethod,
+  ExtendedVerificationMethod,
   multicodecPrefixes,
   nullAddress,
   strip0x,
   toMultibase,
   compressedSecp256k1ToJwk,
-  verificationMethodTypes,
+  VMTypes,
 } from './helpers.js'
 import { logDecoder } from './logParser.js'
 
@@ -55,26 +55,23 @@ function buildLdContext(didDocument: DIDDocument): ContextEntry[] {
 
   // security/v2 defines EcdsaSecp256k1VerificationKey2019, RsaVerificationKey2018,
   // publicKeyBase58, publicKeyPem — add it when any of those types are present.
-  if (
-    types.has(verificationMethodTypes.EcdsaSecp256k1VerificationKey2019) ||
-    types.has(verificationMethodTypes.RsaVerificationKey2018)
-  ) {
+  if (types.has(VMTypes.EcdsaSecp256k1VerificationKey2019) || types.has(VMTypes.RsaVerificationKey2018)) {
     contexts.push('https://w3id.org/security/v2')
   }
 
-  if (types.has(verificationMethodTypes.Ed25519VerificationKey2020)) {
+  if (types.has(VMTypes.Ed25519VerificationKey2020)) {
     contexts.push('https://w3id.org/security/suites/ed25519-2020/v1')
   }
 
-  if (types.has(verificationMethodTypes.X25519KeyAgreementKey2020)) {
+  if (types.has(VMTypes.X25519KeyAgreementKey2020)) {
     contexts.push('https://w3id.org/security/suites/x25519-2020/v1')
   }
 
-  if (types.has(verificationMethodTypes.Bls12381G2Key2020) || types.has(verificationMethodTypes.Bls12381G1Key2020)) {
+  if (types.has(VMTypes.Bls12381G2Key2020) || types.has(VMTypes.Bls12381G1Key2020)) {
     contexts.push('https://w3id.org/security/suites/bls12381-2020/v1')
   }
 
-  if (types.has(verificationMethodTypes.Multikey)) {
+  if (types.has(VMTypes.Multikey)) {
     contexts.push('https://w3id.org/security/multikey/v1')
   }
 
@@ -235,7 +232,7 @@ export class EthrDidResolver {
             case 'veriKey':
               pks[eventIndex] = {
                 id: `${did}#delegate-${delegateCount}`,
-                type: verificationMethodTypes.EcdsaSecp256k1RecoveryMethod2020,
+                type: VMTypes.EcdsaSecp256k1RecoveryMethod2020,
                 controller: did,
                 blockchainAccountId: `eip155:${chainId}:${currentEvent.delegate}`,
               }
@@ -256,35 +253,33 @@ export class EthrDidResolver {
                 // Primary lookup: algorithm token → canonical VM type.
                 // Unknown/future key types pass through as-is.
                 const vmType = algoToVMType[algorithm] ?? algorithm
-                const pk: LegacyVerificationMethod = {
+                const pk: ExtendedVerificationMethod = {
                   id: `${did}#delegate-${delegateCount}`,
                   type: vmType,
                   controller: did,
                 }
                 let keyDataSet = true
                 switch (pk.type) {
-                  case verificationMethodTypes.Ed25519VerificationKey2020:
-                  case verificationMethodTypes.X25519KeyAgreementKey2020:
-                    // Always produce publicKeyMultibase regardless of encoding hint.
+                  case VMTypes.Ed25519VerificationKey2020:
+                  case VMTypes.X25519KeyAgreementKey2020:
+                    // Always produce publicKeyMultibase regardless of encoding hint, to match spec.
                     // On-chain value is always raw key bytes (hex); prepend multicodec prefix.
-                    pk.publicKeyMultibase = toMultibase(
-                      currentEvent.value,
-                      multicodecPrefixes[pk.type as verificationMethodTypes]
-                    )
+                    pk.publicKeyMultibase = toMultibase(currentEvent.value, multicodecPrefixes[pk.type])
                     break
-                  case verificationMethodTypes.Bls12381G2Key2020:
-                  case verificationMethodTypes.Bls12381G1Key2020:
-                    // Always produce publicKeyBase58 of raw bytes regardless of encoding hint.
-                    pk.publicKeyBase58 = encodeBase58(Buffer.from(strip0x(currentEvent.value), 'hex'))
+                  case VMTypes.Bls12381G2Key2020:
+                  case VMTypes.Bls12381G1Key2020:
+                    // Always produce publicKeyBase58 of raw bytes regardless of encoding hint, to match spec.
+                    pk.publicKeyBase58 = encodeBase58(getBytes(`0x${strip0x(currentEvent.value)}`))
                     break
-                  case verificationMethodTypes.Multikey:
+                  case VMTypes.Multikey:
                     // On-chain value already includes the multicodec prefix; just base58btc-encode.
                     pk.publicKeyMultibase = toMultibase(currentEvent.value)
                     break
-                  case verificationMethodTypes.RsaVerificationKey2018:
+                  case VMTypes.RsaVerificationKey2018:
                     // RSA keys must be PEM-encoded UTF-8. Any other encoding hint is invalid.
                     if (encoding === 'pem' || encoding === null || encoding === undefined) {
                       try {
+                        // TODO: this is wrong. The spec example says the raw bytes are DER and need to be b64 encoded and then pre/post fixed to be PEM
                         pk.publicKeyPem = toUtf8String(currentEvent.value)
                       } catch {
                         keyDataSet = false
@@ -294,7 +289,7 @@ export class EthrDidResolver {
                     }
                     break
                   default:
-                    // Secp256k1 and unknown types: honor the encoding hint for legacy compat.
+                    // Unknown key types: honor the encoding hint for legacy compat.
                     switch (encoding) {
                       case null:
                       case undefined:
@@ -386,7 +381,7 @@ export class EthrDidResolver {
     const publicKeys: VerificationMethod[] = [
       {
         id: `${did}#controller`,
-        type: verificationMethodTypes.EcdsaSecp256k1RecoveryMethod2020,
+        type: VMTypes.EcdsaSecp256k1RecoveryMethod2020,
         controller: did,
         blockchainAccountId: `eip155:${chainId}:${controller}`,
       },
@@ -395,7 +390,7 @@ export class EthrDidResolver {
     if (controllerKey && controller == address) {
       publicKeys.push({
         id: `${did}#controllerKey`,
-        type: verificationMethodTypes.EcdsaSecp256k1VerificationKey2019,
+        type: VMTypes.EcdsaSecp256k1VerificationKey2019,
         controller: did,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         publicKeyJwk: compressedSecp256k1ToJwk(controllerKey) as any,

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,6 +1,7 @@
 import { BlockTag, encodeBase58, encodeBase64, toUtf8String } from 'ethers'
 import { ConfigurationOptions, ConfiguredNetworks, configureResolverWithNetworks } from './configuration.js'
-import {
+import type {
+  ContextEntry,
   DIDDocument,
   DIDResolutionOptions,
   DIDResolutionResult,
@@ -19,14 +20,78 @@ import {
   eventNames,
   identifierMatcher,
   interpretIdentifier,
-  legacyAlgoMap,
-  legacyAttrTypes,
+  algoToVMType,
   LegacyVerificationMethod,
+  multicodecPrefixes,
   nullAddress,
   strip0x,
+  toMultibase,
+  compressedSecp256k1ToJwk,
   verificationMethodTypes,
 } from './helpers.js'
 import { logDecoder } from './logParser.js'
+
+/**
+ * Builds the JSON-LD @context array for a DID document based on the verification method types
+ * and key encoding properties actually present in the document.
+ *
+ * - Always includes the base DID v1 and secp256k1recovery-2020/v2 contexts.
+ * - Adds suite-specific contexts only for key types present in the document.
+ * - Appends an inline term definition object for any terms not covered by the above contexts
+ *   (publicKeyHex, publicKeyJwk).
+ */
+function buildLdContext(didDocument: DIDDocument): ContextEntry[] {
+  const contexts: ContextEntry[] = [
+    'https://www.w3.org/ns/did/v1',
+    // defines EcdsaSecp256k1RecoveryMethod2020, blockchainAccountId
+    'https://w3id.org/security/suites/secp256k1recovery-2020/v2',
+  ]
+
+  const allVMs: VerificationMethod[] = didDocument.verificationMethod ?? []
+
+  const types = new Set(allVMs.map((vm) => vm.type))
+  const hasPublicKeyHex = allVMs.some((vm) => 'publicKeyHex' in vm)
+  const hasPublicKeyJwk = allVMs.some((vm) => 'publicKeyJwk' in vm)
+
+  // security/v2 defines EcdsaSecp256k1VerificationKey2019, RsaVerificationKey2018,
+  // publicKeyBase58, publicKeyPem — add it when any of those types are present.
+  if (
+    types.has(verificationMethodTypes.EcdsaSecp256k1VerificationKey2019) ||
+    types.has(verificationMethodTypes.RsaVerificationKey2018)
+  ) {
+    contexts.push('https://w3id.org/security/v2')
+  }
+
+  if (types.has(verificationMethodTypes.Ed25519VerificationKey2020)) {
+    contexts.push('https://w3id.org/security/suites/ed25519-2020/v1')
+  }
+
+  if (types.has(verificationMethodTypes.X25519KeyAgreementKey2020)) {
+    contexts.push('https://w3id.org/security/suites/x25519-2020/v1')
+  }
+
+  if (types.has(verificationMethodTypes.Bls12381G2Key2020) || types.has(verificationMethodTypes.Bls12381G1Key2020)) {
+    contexts.push('https://w3id.org/security/suites/bls12381-2020/v1')
+  }
+
+  if (types.has(verificationMethodTypes.Multikey)) {
+    contexts.push('https://w3id.org/security/multikey/v1')
+  }
+
+  // Inline term definitions for properties not defined by any of the above contexts.
+  const inline: Record<string, unknown> = {}
+  if (hasPublicKeyHex) {
+    inline['publicKeyHex'] = 'https://w3id.org/security#publicKeyHex'
+  }
+  if (hasPublicKeyJwk) {
+    inline['publicKeyJwk'] = { '@id': 'https://w3id.org/security#publicKeyJwk', '@type': '@json' }
+  }
+  if (Object.keys(inline).length > 0) {
+    contexts.push(inline)
+  }
+
+  return contexts
+}
 
 export function getResolver(options: ConfigurationOptions): Record<string, DIDResolver> {
   return new EthrDidResolver(options).build()
@@ -184,40 +249,74 @@ export class EthrDidResolver {
           if (match) {
             const section = match[1]
             const algorithm = match[2]
-            const type = legacyAttrTypes[match[4]] || match[4]
             const encoding = match[6]
             switch (section) {
               case 'pub': {
                 delegateCount++
+                // Primary lookup: algorithm token → canonical VM type.
+                // Unknown/future key types pass through as-is.
+                const vmType = algoToVMType[algorithm] ?? algorithm
                 const pk: LegacyVerificationMethod = {
                   id: `${did}#delegate-${delegateCount}`,
-                  type: `${algorithm}${type}`,
+                  type: vmType,
                   controller: did,
                 }
-                pk.type = legacyAlgoMap[pk.type] || algorithm
                 let keyDataSet = true
-                switch (encoding) {
-                  case null:
-                  case undefined:
-                  case 'hex':
-                    pk.publicKeyHex = strip0x(currentEvent.value)
+                switch (pk.type) {
+                  case verificationMethodTypes.Ed25519VerificationKey2020:
+                  case verificationMethodTypes.X25519KeyAgreementKey2020:
+                    // Always produce publicKeyMultibase regardless of encoding hint.
+                    // On-chain value is always raw key bytes (hex); prepend multicodec prefix.
+                    pk.publicKeyMultibase = toMultibase(
+                      currentEvent.value,
+                      multicodecPrefixes[pk.type as verificationMethodTypes]
+                    )
                     break
-                  case 'base64':
-                    pk.publicKeyBase64 = encodeBase64(currentEvent.value)
+                  case verificationMethodTypes.Bls12381G2Key2020:
+                  case verificationMethodTypes.Bls12381G1Key2020:
+                    // Always produce publicKeyBase58 of raw bytes regardless of encoding hint.
+                    pk.publicKeyBase58 = encodeBase58(Buffer.from(strip0x(currentEvent.value), 'hex'))
                     break
-                  case 'base58':
-                    pk.publicKeyBase58 = encodeBase58(currentEvent.value)
+                  case verificationMethodTypes.Multikey:
+                    // On-chain value already includes the multicodec prefix; just base58btc-encode.
+                    pk.publicKeyMultibase = toMultibase(currentEvent.value)
                     break
-                  case 'pem':
-                    try {
-                      pk.publicKeyPem = toUtf8String(currentEvent.value)
-                    } catch {
-                      // value is not valid UTF-8; skip this key — non-DID use of registry
+                  case verificationMethodTypes.RsaVerificationKey2018:
+                    // RSA keys must be PEM-encoded UTF-8. Any other encoding hint is invalid.
+                    if (encoding === 'pem' || encoding === null || encoding === undefined) {
+                      try {
+                        pk.publicKeyPem = toUtf8String(currentEvent.value)
+                      } catch {
+                        keyDataSet = false
+                      }
+                    } else {
                       keyDataSet = false
                     }
                     break
                   default:
-                    pk.value = strip0x(currentEvent.value)
+                    // Secp256k1 and unknown types: honor the encoding hint for legacy compat.
+                    switch (encoding) {
+                      case null:
+                      case undefined:
+                      case 'hex':
+                        pk.publicKeyHex = strip0x(currentEvent.value)
+                        break
+                      case 'base64':
+                        pk.publicKeyBase64 = encodeBase64(currentEvent.value)
+                        break
+                      case 'base58':
+                        pk.publicKeyBase58 = encodeBase58(currentEvent.value)
+                        break
+                      case 'pem':
+                        try {
+                          pk.publicKeyPem = toUtf8String(currentEvent.value)
+                        } catch {
+                          keyDataSet = false
+                        }
+                        break
+                      default:
+                        pk.value = strip0x(currentEvent.value)
+                    }
                 }
                 if (keyDataSet) {
                   pks[eventIndex] = pk
@@ -298,7 +397,8 @@ export class EthrDidResolver {
         id: `${did}#controllerKey`,
         type: verificationMethodTypes.EcdsaSecp256k1VerificationKey2019,
         controller: did,
-        publicKeyHex: strip0x(controllerKey),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        publicKeyJwk: compressedSecp256k1ToJwk(controllerKey) as any,
       })
       authentication.push(`${did}#controllerKey`)
       assertionMethod.push(`${did}#controllerKey`)
@@ -333,21 +433,11 @@ export class EthrDidResolver {
     _unused: Resolvable,
     options: DIDResolutionOptions
   ): Promise<DIDResolutionResult> {
-    let ldContext = {}
+    let wantLdContext = false
     if (options.accept === 'application/did+json') {
-      ldContext = {}
+      wantLdContext = false
     } else if (options.accept === 'application/did+ld+json' || typeof options.accept !== 'string') {
-      ldContext = {
-        '@context': [
-          'https://www.w3.org/ns/did/v1',
-
-          // defines EcdsaSecp256k1RecoveryMethod2020 & blockchainAccountId
-          'https://w3id.org/security/suites/secp256k1recovery-2020/v2',
-
-          // defines publicKeyHex & EcdsaSecp256k1VerificationKey2019; v2 does not define publicKeyHex
-          'https://w3id.org/security/v3-unstable',
-        ],
-      }
+      wantLdContext = true
     } else {
       return {
         didResolutionMetadata: {
@@ -436,7 +526,7 @@ export class EthrDidResolver {
         didResolutionMetadata: { contentType: options.accept ?? 'application/did+ld+json' },
         didDocument: {
           ...didDocument,
-          ...ldContext,
+          ...(wantLdContext ? { '@context': buildLdContext(didDocument) } : {}),
         },
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -279,7 +279,6 @@ export class EthrDidResolver {
                   type: vmType,
                   controller: did,
                 }
-                let keyDataSet = true
                 switch (pk.type) {
                   case VMTypes.EcdsaSecp256k1VerificationKey2019:
                     // Spec mandates publicKeyJwk for Secp256k1 attribute keys regardless of encoding hint.
@@ -300,12 +299,9 @@ export class EthrDidResolver {
                     pk.publicKeyMultibase = toMultibase(currentEvent.value)
                     break
                   case VMTypes.RsaVerificationKey2018:
-                    // RSA keys must be PEM-encoded UTF-8. Any other encoding hint is invalid.
-                    if (encoding === 'pem' || encoding === null || encoding === undefined) {
-                      pk.publicKeyPem = bytesToPem(currentEvent.value)
-                    } else {
-                      keyDataSet = false
-                    }
+                    // Encoding hint is ignored for RSA — always emit publicKeyPem,
+                    // consistent with how other known key types use their canonical encoding.
+                    pk.publicKeyPem = bytesToPem(currentEvent.value)
                     break
                   default:
                     // Unknown key types: honor the encoding hint for legacy compat.
@@ -328,16 +324,14 @@ export class EthrDidResolver {
                         pk.value = strip0x(currentEvent.value)
                     }
                 }
-                if (keyDataSet) {
-                  pks[eventIndex] = pk
-                  if (match[4] === 'sigAuth') {
-                    auth[eventIndex] = pk.id
-                    signingRefs[eventIndex] = pk.id
-                  } else if (match[4] === 'enc') {
-                    keyAgreementRefs[eventIndex] = pk.id
-                  } else {
-                    signingRefs[eventIndex] = pk.id
-                  }
+                pks[eventIndex] = pk
+                if (match[4] === 'sigAuth') {
+                  auth[eventIndex] = pk.id
+                  signingRefs[eventIndex] = pk.id
+                } else if (match[4] === 'enc') {
+                  keyAgreementRefs[eventIndex] = pk.id
+                } else {
+                  signingRefs[eventIndex] = pk.id
                 }
                 break
               }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -401,8 +401,7 @@ export class EthrDidResolver {
         id: `${did}#controllerKey`,
         type: VMTypes.EcdsaSecp256k1VerificationKey2019,
         controller: did,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        publicKeyJwk: compressedSecp256k1ToJwk(controllerKey) as any,
+        publicKeyJwk: compressedSecp256k1ToJwk(controllerKey),
       })
       authentication.push(`${did}#controllerKey`)
       assertionMethod.push(`${did}#controllerKey`)

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -53,10 +53,18 @@ function buildLdContext(didDocument: DIDDocument): ContextEntry[] {
   const types = new Set(allVMs.map((vm) => vm.type))
   const hasPublicKeyHex = allVMs.some((vm) => 'publicKeyHex' in vm)
   const hasPublicKeyJwk = allVMs.some((vm) => 'publicKeyJwk' in vm)
+  const hasPublicKeyBase58 = allVMs.some((vm) => 'publicKeyBase58' in vm)
+  const hasPublicKeyPem = allVMs.some((vm) => 'publicKeyPem' in vm)
+  const hasPublicKeyBase64 = allVMs.some((vm) => 'publicKeyBase64' in vm)
 
   // security/v2 defines EcdsaSecp256k1VerificationKey2019, RsaVerificationKey2018,
-  // publicKeyBase58, publicKeyPem — add it when any of those types are present.
-  if (types.has(VMTypes.EcdsaSecp256k1VerificationKey2019) || types.has(VMTypes.RsaVerificationKey2018)) {
+  // publicKeyBase58, publicKeyPem — add it when any of those types or properties are present.
+  if (
+    types.has(VMTypes.EcdsaSecp256k1VerificationKey2019) ||
+    types.has(VMTypes.RsaVerificationKey2018) ||
+    hasPublicKeyBase58 ||
+    hasPublicKeyPem
+  ) {
     contexts.push('https://w3id.org/security/v2')
   }
 
@@ -77,12 +85,24 @@ function buildLdContext(didDocument: DIDDocument): ContextEntry[] {
   }
 
   // Inline term definitions for properties not defined by any of the above contexts.
+  const securityV2Included = contexts.includes('https://w3id.org/security/v2')
   const inline: Record<string, unknown> = {}
   if (hasPublicKeyHex) {
     inline['publicKeyHex'] = 'https://w3id.org/security#publicKeyHex'
   }
   if (hasPublicKeyJwk) {
     inline['publicKeyJwk'] = { '@id': 'https://w3id.org/security#publicKeyJwk', '@type': '@json' }
+  }
+  // publicKeyBase58/publicKeyPem are defined by security/v2; only add inline if that context is absent.
+  if (hasPublicKeyBase58 && !securityV2Included) {
+    inline['publicKeyBase58'] = 'https://w3id.org/security#publicKeyBase58'
+  }
+  if (hasPublicKeyPem && !securityV2Included) {
+    inline['publicKeyPem'] = 'https://w3id.org/security#publicKeyPem'
+  }
+  // publicKeyBase64 is not defined by any suite context — always inline when present.
+  if (hasPublicKeyBase64) {
+    inline['publicKeyBase64'] = 'https://w3id.org/security#publicKeyBase64'
   }
   if (Object.keys(inline).length > 0) {
     contexts.push(inline)

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,4 +1,4 @@
-import { BlockTag, encodeBase58, encodeBase64, getBytes, toUtf8String } from 'ethers'
+import { BlockTag, encodeBase58, encodeBase64, toUtf8String } from 'ethers'
 import { ConfigurationOptions, ConfiguredNetworks, configureResolverWithNetworks } from './configuration.js'
 import type {
   ContextEntry,
@@ -12,21 +12,21 @@ import type {
   VerificationMethod,
 } from 'did-resolver'
 import {
+  algoToVMType,
+  compressedSecp256k1ToJwk,
   DIDAttributeChanged,
   DIDDelegateChanged,
   DIDOwnerChanged,
   ERC1056Event,
   Errors,
   eventNames,
+  ExtendedVerificationMethod,
   identifierMatcher,
   interpretIdentifier,
-  algoToVMType,
-  ExtendedVerificationMethod,
   multicodecPrefixes,
   nullAddress,
   strip0x,
   toMultibase,
-  compressedSecp256k1ToJwk,
   VMTypes,
 } from './helpers.js'
 import { logDecoder } from './logParser.js'
@@ -55,8 +55,7 @@ function buildLdContext(didDocument: DIDDocument): ContextEntry[] {
   const hasPublicKeyBase58 = allVMs.some((vm) => 'publicKeyBase58' in vm)
   const hasPublicKeyBase64 = allVMs.some((vm) => 'publicKeyBase64' in vm)
 
-  // security/v2 defines EcdsaSecp256k1VerificationKey2019,
-  // publicKeyBase58 — add it when any of those types or properties are present.
+  // security/v2 defines EcdsaSecp256k1VerificationKey2019 & publicKeyBase58
   if (types.has(VMTypes.EcdsaSecp256k1VerificationKey2019) || hasPublicKeyBase58) {
     contexts.push('https://w3id.org/security/v2')
   }
@@ -67,10 +66,6 @@ function buildLdContext(didDocument: DIDDocument): ContextEntry[] {
 
   if (types.has(VMTypes.X25519KeyAgreementKey2020)) {
     contexts.push('https://w3id.org/security/suites/x25519-2020/v1')
-  }
-
-  if (types.has(VMTypes.Bls12381G2Key2020) || types.has(VMTypes.Bls12381G1Key2020)) {
-    contexts.push('https://w3id.org/security/suites/bls12381-2020/v1')
   }
 
   if (types.has(VMTypes.Multikey)) {
@@ -236,6 +231,7 @@ export class EthrDidResolver {
           const currentEvent = event as DIDDelegateChanged
           delegateCount++
           const delegateType = currentEvent.delegateType //conversion from bytes32 is done in logParser
+          // noinspection FallThroughInSwitchStatementJS
           switch (delegateType) {
             case 'sigAuth':
               auth[eventIndex] = `${did}#delegate-${delegateCount}`
@@ -278,11 +274,6 @@ export class EthrDidResolver {
                   case VMTypes.X25519KeyAgreementKey2020:
                     // Always produce publicKeyMultibase regardless of encoding hint, to match spec.
                     pk.publicKeyMultibase = toMultibase(currentEvent.value, multicodecPrefixes[pk.type])
-                    break
-                  case VMTypes.Bls12381G2Key2020:
-                  case VMTypes.Bls12381G1Key2020:
-                    // Always produce publicKeyBase58 of raw bytes regardless of encoding hint, to match spec.
-                    pk.publicKeyBase58 = encodeBase58(getBytes(`0x${strip0x(currentEvent.value)}`))
                     break
                   case VMTypes.Multikey:
                     // On-chain value already includes the multicodec prefix; just base58btc-encode.


### PR DESCRIPTION
This set of changes updates the way the resolver interprets public keys from `DIDAttributeChanged` events.

fixes #228

The most important change is that the encoding hint from the bytes32 event name is mostly ignored in favor of respecting the canonical key encoding required by each Verification Method (VM) definition.

Secondly, some of the previously known key types are now decoded as the more modern VM definition. The new mapping is this:

| Key algo | VM type | key encoding |
|--|--|--|
| `Secp256k1` | `EcdsaSecp256k1VerificationKey2019` | `publicKeyJwk` |
| `Ed25519` | `Ed25519VerificationKey2020` | `publicKeyMultibase` |
| `X25519` | `X25519KeyAgreementKey2020` | `publicKeyMultibase` |

The existing on-chain encoding of these keys is still supported (raw key material). What is updated is the way this key material is presented in the resolved DID document.
For RSA keys the raw key material can now be the raw bytes of the DER encoding. The resolver will base64 encode it and prefix it properly to be used as PEM. The raw utf8 decoding is still tried first, to maintain backwards compatibility for existing RSA keys.

---

The `Multikey` verification method type is now natively supported:

| Key algo | VM type | key encoding |
|--|--|--|
| `Multikey` | `Multikey` | `publicKeyMultibase` |

Importantly, any key type that has a known prefix in [the multicodec table](https://github.com/multiformats/multicodec) can be used with `Multikey`. The on-chain key material MUST contain the multicodec prefix, as there is no other hint to the key type. All known key types can also be added as Multikey. Watch out for the varint prefix in multicodec.

---

Direct support for `Bls12381G2Key2020` (and G1), used for [the original BBS+ implementation](https://github.com/mattrglobal/jsonld-signatures-bbs), was considered but it is already superseeded by `Multikey` in [the more recent vc-di-bbs spec](https://w3c.github.io/vc-di-bbs/#multikey)

---

All these new key encodings and verification method types now map to their corresponding JSON-LD `@context` definitions.

---

These VM types are no longer returned by this resolver:
* `Secp256k1VerificationKey2018` => `EcdsaSecp256k1VerificationKey2019`
* `Secp256k1SignatureAuthentication2018` => `EcdsaSecp256k1VerificationKey2019`
* `Ed25519SignatureAuthentication2018` => `Ed25519VerificationKey2020`
* `Ed25519VerificationKey2018` => `Ed25519VerificationKey2020`
* `X25519KeyAgreementKey2019` => `X25519KeyAgreementKey2020`
* `RSA` => `RsaVerificationKey2018`

RSA keys can be encoded as Multikey. There is no history of RSA keys being used in their current form on any of the known registry deployments. The only usage is on Energy Web chains, with a different encoding.

---

BREAKING CHANGE: the default `REGISTRY` is no longer exported. It does not map to any default anymore.

BREAKING CHANGE: Ed25519VerificationKey2018/X25519KeyAgreementKey2019 VM methods now map to their 2020 definitions

BREAKING CHANGE: RSA keys no longer directly handled. There is no history of usage, but still counts as breaking.

BREAKING CHANGE: The encoding hint from `DIDAttributeChanged` is only used when the key type is unknown. If none is specified, `publicKeyHex` is used.

BREAKING CHANGE: `attrTypes` and `delegateTypes` are no longer exported as they mapped to the deprecated VM names.