### PR TITLE
Refactor event processing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 11.5.0
-      - name: 'Setup Node.js with pnpm cache'
+      - name: 'Setup Node.js'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,4 @@ $RECYCLE.BIN/
 # End of https://www.gitignore.io/api/node,linux,macos,windows,intellij
 
 dist/
+/planning/

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -11,8 +11,8 @@ describe('configuration', () => {
     expect(contracts['mainnet']).toBeDefined()
     expect(contracts['0x1']).toBeDefined()
     expect(contracts['dev']).toBeDefined()
-    expect(contracts['linea:goerli']).toBeDefined()
-    expect(contracts['0xe704']).toBeDefined()
+    expect(contracts['aurora']).toBeDefined()
+    expect(contracts['0x4e454152']).toBeDefined()
   })
 
   it('works with infuraProjectId and overrides', () => {
@@ -26,19 +26,19 @@ describe('configuration', () => {
 
   it('works with named network', async () => {
     const contracts = configureResolverWithNetworks({
-      networks: [{ name: 'linea:goerli', provider: new JsonRpcProvider('some goerli JSONRPC URL') }],
+      networks: [{ name: 'aurora', provider: new JsonRpcProvider('some JSONRPC URL') }],
     })
-    expect(contracts['linea:goerli']).toBeDefined()
-    expect(contracts['0xe704']).toBeDefined()
+    expect(contracts['aurora']).toBeDefined()
+    expect(contracts['0x4e454152']).toBeDefined()
   })
 
   it('works with single network', async () => {
     const contracts = configureResolverWithNetworks({
-      name: 'linea:goerli',
-      provider: new JsonRpcProvider('some goerli JSONRPC URL'),
+      name: 'aurora',
+      provider: new JsonRpcProvider('some JSONRPC URL'),
     })
-    expect(contracts['linea:goerli']).toBeDefined()
-    expect(contracts['0xe704']).toBeDefined()
+    expect(contracts['aurora']).toBeDefined()
+    expect(contracts['0x4e454152']).toBeDefined()
   })
 
   it('works with single provider', async () => {
@@ -68,24 +68,24 @@ describe('configuration', () => {
   it('throws when no configuration is provided', () => {
     expect(() => {
       configureResolverWithNetworks()
-    }).toThrowError('invalid_config: Please make sure to have at least one network')
+    }).toThrow('invalid_config: Please make sure to have at least one network')
   })
 
   it('throws when no registry is known for a network', () => {
     expect(() => {
       configureResolverWithNetworks({ networks: [{ name: 'unknown-net', rpcUrl: 'http://localhost:8545' }] })
-    }).toThrowError('invalid_config: No registry address known for network unknown-net')
+    }).toThrow('invalid_config: No registry address known for network unknown-net')
   })
 
   it('throws when no relevant configuration is provided for a network', () => {
     expect(() => {
       configureResolverWithNetworks({ networks: [{ chainId: '0xbad' }] })
-    }).toThrowError('invalid_config: No web3 provider could be determined for network')
+    }).toThrow('invalid_config: No web3 provider could be determined for network')
   })
 
   it('throws when malformed configuration is provided for a network', () => {
     expect(() => {
       configureResolverWithNetworks({ networks: [{ web3: '0xbad' }] })
-    }).toThrowError('invalid_config: No web3 provider could be determined for network')
+    }).toThrow('invalid_config: No web3 provider could be determined for network')
   })
 })

--- a/src/__tests__/resolve.attribute.test.ts
+++ b/src/__tests__/resolve.attribute.test.ts
@@ -504,6 +504,54 @@ describe('attributes', () => {
       })
     })
 
+    it('revokes X25519 keyAgreement key and removes keyAgreement section', async () => {
+      expect.assertions(2)
+      const { address: identity, shortDID: did, signer } = await randomAccount(provider)
+      const pubKeyBase64 = 'MCowBQYDK2VuAyEAEYVXd3/7B4d0NxpSsA/tdVYdz5deYcR1U+ZkphdmEFI='
+      const pubKeyHex = ethers.hexlify(ethers.decodeBase64(pubKeyBase64))
+      await new EthrDidController(did, registryContract, signer).setAttribute('did/pub/X25519/enc', pubKeyHex, 86404)
+      const { didDocument: didDocumentBefore } = await didResolver.resolve(did)
+      expect(didDocumentBefore).toEqual({
+        '@context': expect.anything(),
+        id: did,
+        verificationMethod: [
+          {
+            id: `${did}#controller`,
+            type: 'EcdsaSecp256k1RecoveryMethod2020',
+            controller: did,
+            blockchainAccountId: `eip155:1337:${identity}`,
+          },
+          {
+            id: `${did}#delegate-1`,
+            type: 'X25519KeyAgreementKey2020',
+            controller: did,
+            publicKeyMultibase: toMultibase(pubKeyHex, new Uint8Array([0xec, 0x01])),
+          },
+        ],
+        authentication: [`${did}#controller`],
+        assertionMethod: [`${did}#controller`],
+        keyAgreement: [`${did}#delegate-1`],
+      })
+
+      await new EthrDidController(did, registryContract, signer).revokeAttribute('did/pub/X25519/enc', pubKeyHex)
+
+      const { didDocument: didDocumentAfter } = await didResolver.resolve(did)
+      expect(didDocumentAfter).toEqual({
+        '@context': expect.anything(),
+        id: did,
+        verificationMethod: [
+          {
+            id: `${did}#controller`,
+            type: 'EcdsaSecp256k1RecoveryMethod2020',
+            controller: did,
+            blockchainAccountId: `eip155:1337:${identity}`,
+          },
+        ],
+        authentication: [`${did}#controller`],
+        assertionMethod: [`${did}#controller`],
+      })
+    })
+
     it('expires key automatically', async () => {
       expect.assertions(2)
       const { address: identity, shortDID: did, signer } = await randomAccount(provider)

--- a/src/__tests__/resolve.unregistered.test.ts
+++ b/src/__tests__/resolve.unregistered.test.ts
@@ -3,7 +3,7 @@ import { BrowserProvider } from 'ethers'
 import { Resolvable } from 'did-resolver'
 
 import { deployRegistry, randomAccount } from './testUtils'
-import { compressedSecp256k1ToJwk } from '../helpers'
+import { secp256k1ToJwk } from '../helpers'
 
 describe('unregistered DIDs', () => {
   let didResolver: Resolvable, provider: BrowserProvider
@@ -58,7 +58,7 @@ describe('unregistered DIDs', () => {
             id: `${longDID}#controllerKey`,
             type: 'EcdsaSecp256k1VerificationKey2019',
             controller: longDID,
-            publicKeyJwk: compressedSecp256k1ToJwk(pubKey),
+            publicKeyJwk: secp256k1ToJwk(pubKey),
           },
         ],
         authentication: [`${longDID}#controller`, `${longDID}#controllerKey`],
@@ -86,7 +86,7 @@ describe('unregistered DIDs', () => {
             id: `${pubdid}#controllerKey`,
             type: 'EcdsaSecp256k1VerificationKey2019',
             controller: pubdid,
-            publicKeyJwk: compressedSecp256k1ToJwk(pubKey),
+            publicKeyJwk: secp256k1ToJwk(pubKey),
           },
         ],
         authentication: [`${pubdid}#controller`, `${pubdid}#controllerKey`],
@@ -114,7 +114,7 @@ describe('unregistered DIDs', () => {
             id: `${pubdid}#controllerKey`,
             type: 'EcdsaSecp256k1VerificationKey2019',
             controller: pubdid,
-            publicKeyJwk: compressedSecp256k1ToJwk(pubKey),
+            publicKeyJwk: secp256k1ToJwk(pubKey),
           },
         ],
         authentication: [`${pubdid}#controller`, `${pubdid}#controllerKey`],

--- a/src/config/deployments.ts
+++ b/src/config/deployments.ts
@@ -41,12 +41,14 @@ export type EthrDidRegistryDeployment = {
  */
 export const deployments: EthrDidRegistryDeployment[] = [
   { chainId: 1, registry: '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b', name: 'mainnet', legacyNonce: true },
+  // // deprecated networks
   // { chainId: 3, registry: '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b', name: 'ropsten', legacyNonce: true },
   // { chainId: 4, registry: '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b', name: 'rinkeby', legacyNonce: true },
   // { chainId: 5, registry: '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b', name: 'goerli', legacyNonce: true },
   { chainId: 11155111, registry: '0x03d5003bf0e79C5F5223588F347ebA39AfbC3818', name: 'sepolia', legacyNonce: false },
   { chainId: 100, registry: '0x03d5003bf0e79C5F5223588F347ebA39AfbC3818', name: 'gno', legacyNonce: false },
   { chainId: 17000, registry: '0x03d5003bf0e79C5F5223588F347ebA39AfbC3818', name: 'holesky', legacyNonce: false },
+  // deprecated networks
   // { chainId: 42, registry: '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b', name: 'kovan', legacyNonce: true },
   // // rsk networks cause socket hang up
   // { chainId: 30, registry: '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b', name: 'rsk', legacyNonce: true },
@@ -97,7 +99,7 @@ export const deployments: EthrDidRegistryDeployment[] = [
     name: 'aurora',
     legacyNonce: true,
   },
-  // deprecated
+  // // deprecated
   // {
   //   chainId: 59140,
   //   registry: '0x03d5003bf0e79C5F5223588F347ebA39AfbC3818',

--- a/src/config/deployments.ts
+++ b/src/config/deployments.ts
@@ -70,35 +70,38 @@ export const deployments: EthrDidRegistryDeployment[] = [
     description: 'energy web testnet',
     legacyNonce: false,
   },
-  {
-    chainId: 246785,
-    registry: '0xdCa7EF03e98e0DC2B855bE647C39ABe984fcF21B',
-    name: 'artis:tau1',
-    legacyNonce: true,
-  },
-  {
-    chainId: 246529,
-    registry: '0xdCa7EF03e98e0DC2B855bE647C39ABe984fcF21B',
-    name: 'artis:sigma1',
-    legacyNonce: true,
-  },
+  // // deprecated networks
+  // {
+  //   chainId: 246785,
+  //   registry: '0xdCa7EF03e98e0DC2B855bE647C39ABe984fcF21B',
+  //   name: 'artis:tau1',
+  //   legacyNonce: true,
+  // },
+  // {
+  //   chainId: 246529,
+  //   registry: '0xdCa7EF03e98e0DC2B855bE647C39ABe984fcF21B',
+  //   name: 'artis:sigma1',
+  //   legacyNonce: true,
+  // },
   { chainId: 137, registry: '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b', name: 'polygon', legacyNonce: true },
-  {
-    chainId: 80001,
-    registry: '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b',
-    name: 'polygon:test',
-    legacyNonce: true,
-  },
+  // // deprecated
+  // {
+  //   chainId: 80001,
+  //   registry: '0xdca7ef03e98e0dc2b855be647c39abe984fcf21b',
+  //   name: 'polygon:test',
+  //   legacyNonce: true,
+  // },
   {
     chainId: 1313161554,
     registry: '0x63eD58B671EeD12Bc1652845ba5b2CDfBff198e0',
     name: 'aurora',
     legacyNonce: true,
   },
-  {
-    chainId: 59140,
-    registry: '0x03d5003bf0e79C5F5223588F347ebA39AfbC3818',
-    name: 'linea:goerli',
-    legacyNonce: false,
-  },
+  // deprecated
+  // {
+  //   chainId: 59140,
+  //   registry: '0x03d5003bf0e79C5F5223588F347ebA39AfbC3818',
+  //   name: 'linea:goerli',
+  //   legacyNonce: false,
+  // },
 ]

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -8,7 +8,7 @@ const infuraNames: Record<string, string> = {
   aurora: 'aurora-mainnet',
 }
 
-const knownInfuraNames = ['mainnet', 'aurora', 'linea:goerli', 'sepolia']
+const knownInfuraNames = ['mainnet', 'aurora', 'sepolia']
 
 /**
  * A configuration entry for an ethereum network

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,29 +20,47 @@ export type uint256 = bigint
 export type bytes32 = string
 export type bytes = string
 
-export interface ERC1056Event {
+/**
+ * Common fields shared by all ERC-1056 events.
+ */
+type ERC1056Base = {
   identity: address
   previousChange: uint256
-  validTo?: bigint
-  _eventName: string
   blockNumber: number
 }
 
-export interface DIDOwnerChanged extends ERC1056Event {
+/**
+ * ERC-1056 owner change event — no `validTo`.
+ */
+export type DIDOwnerChanged = ERC1056Base & {
+  _eventName: 'DIDOwnerChanged'
   owner: address
 }
 
-export interface DIDAttributeChanged extends ERC1056Event {
+/**
+ * ERC-1056 attribute change event.
+ */
+export type DIDAttributeChanged = ERC1056Base & {
+  _eventName: 'DIDAttributeChanged'
   name: bytes32
   value: bytes
   validTo: uint256
 }
 
-export interface DIDDelegateChanged extends ERC1056Event {
+/**
+ * ERC-1056 delegate change event.
+ */
+export type DIDDelegateChanged = ERC1056Base & {
+  _eventName: 'DIDDelegateChanged'
   delegateType: bytes32
   delegate: address
   validTo: uint256
 }
+
+/**
+ * Discriminated union of all ERC-1056 event types.
+ */
+export type ERC1056Event = DIDOwnerChanged | DIDAttributeChanged | DIDDelegateChanged
 
 export const VMTypes = {
   EcdsaSecp256k1VerificationKey2019: 'EcdsaSecp256k1VerificationKey2019',
@@ -184,7 +202,7 @@ export function toMultibase(hexValue: string, prefix?: Uint8Array): string {
  * Decompresses a 33-byte secp256k1 public key (hex, with or without 0x prefix) and
  * returns a JWK object suitable for use as `publicKeyJwk` in a DID document.
  */
-export function compressedSecp256k1ToJwk(hex: string): JsonWebKey {
+export function secp256k1ToJwk(hex: string): JsonWebKey {
   const uncompressed = SigningKey.computePublicKey(hex.startsWith('0x') ? hex : `0x${hex}`, false)
   // uncompressed is 0x04 || x (32 bytes) || y (32 bytes)
   const raw = getBytes(uncompressed)

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -13,10 +13,7 @@ import type {
 } from 'did-resolver'
 import {
   algoToVMType,
-  compressedSecp256k1ToJwk,
-  DIDAttributeChanged,
-  DIDDelegateChanged,
-  DIDOwnerChanged,
+  secp256k1ToJwk,
   ERC1056Event,
   Errors,
   eventNames,
@@ -101,7 +98,7 @@ export function getResolver(options: ConfigurationOptions): Record<string, DIDRe
 }
 
 export class EthrDidResolver {
-  private contracts: ConfiguredNetworks
+  private readonly contracts: ConfiguredNetworks
 
   constructor(options: ConfigurationOptions) {
     this.contracts = configureResolverWithNetworks(options)
@@ -201,7 +198,6 @@ export class EthrDidResolver {
     let deactivated = false
     let delegateCount = 0
     let serviceCount = 0
-    let endpoint = ''
     const auth: Record<string, string> = {}
     const keyAgreementRefs: Record<string, string> = {}
     const signingRefs: Record<string, string> = {}
@@ -222,41 +218,54 @@ export class EthrDidResolver {
           versionId = event.blockNumber
         }
       }
-      const validTo = event.validTo || BigInt(0)
-      const eventIndex = `${event._eventName}-${
-        (event as DIDDelegateChanged).delegateType || (event as DIDAttributeChanged).name
-      }-${(event as DIDDelegateChanged).delegate || (event as DIDAttributeChanged).value}`
-      if (validTo && validTo >= now) {
-        if (event._eventName === eventNames.DIDDelegateChanged) {
-          const currentEvent = event as DIDDelegateChanged
-          delegateCount++
-          const delegateType = currentEvent.delegateType //conversion from bytes32 is done in logParser
+      if (event._eventName === eventNames.DIDOwnerChanged) {
+        controller = event.owner
+        if (event.owner === nullAddress) {
+          deactivated = true
+          break
+        }
+      } else if (event._eventName === eventNames.DIDDelegateChanged) {
+        const eventIndex = `${event._eventName}-${event.delegateType}-${event.delegate}`
+        delegateCount++
+        if (event.validTo >= now) {
+          // addition
+          const delegateType = event.delegateType //conversion from bytes32 is done in logParser
           // noinspection FallThroughInSwitchStatementJS
           switch (delegateType) {
             case 'sigAuth':
               auth[eventIndex] = `${did}#delegate-${delegateCount}`
-              signingRefs[eventIndex] = `${did}#delegate-${delegateCount}`
+            // intentionally fall through. Authoritative keys can also make assertions.
             case 'veriKey':
               pks[eventIndex] = {
                 id: `${did}#delegate-${delegateCount}`,
                 type: VMTypes.EcdsaSecp256k1RecoveryMethod2020,
                 controller: did,
-                blockchainAccountId: `eip155:${chainId}:${currentEvent.delegate}`,
+                blockchainAccountId: `eip155:${chainId}:${event.delegate}`,
               }
               signingRefs[eventIndex] = `${did}#delegate-${delegateCount}`
               break
           }
-        } else if (event._eventName === eventNames.DIDAttributeChanged) {
-          const currentEvent = event as DIDAttributeChanged
-          const name = currentEvent.name //conversion from bytes32 is done in logParser
-          const match = name.match(/^did\/(pub|svc)\/(\w+)(\/(\w+))?(\/(\w+))?$/)
-          if (match) {
-            const section = match[1]
-            const algorithm = match[2]
-            const encoding = match[6]
-            switch (section) {
-              case 'pub': {
-                delegateCount++
+        } else {
+          // revocation
+          delete auth[eventIndex]
+          delete signingRefs[eventIndex]
+          delete pks[eventIndex]
+        }
+      } else if (event._eventName === eventNames.DIDAttributeChanged) {
+        const eventIndex = `${event._eventName}-${event.name}-${event.value}`
+
+        if (/^did\/pub\//.test(event.name)) delegateCount++
+        else if (/^did\/svc\//.test(event.name)) serviceCount++
+
+        const match = event.name.match(/^did\/(pub|svc)\/(\w+)(\/(\w+))?(\/(\w+))?$/)
+        if (match) {
+          const section = match[1]
+          const algorithm = match[2]
+          const encoding = match[6]
+          switch (section) {
+            case 'pub': {
+              // addition
+              if (event.validTo >= now) {
                 // Primary lookup: algorithm token → canonical VM type.
                 // Unknown/future key types pass through as-is.
                 const vmType = algoToVMType[algorithm] ?? algorithm
@@ -268,16 +277,16 @@ export class EthrDidResolver {
                 switch (pk.type) {
                   case VMTypes.EcdsaSecp256k1VerificationKey2019:
                     // Spec mandates publicKeyJwk for Secp256k1 attribute keys regardless of encoding hint.
-                    pk.publicKeyJwk = compressedSecp256k1ToJwk(currentEvent.value)
+                    pk.publicKeyJwk = secp256k1ToJwk(event.value)
                     break
                   case VMTypes.Ed25519VerificationKey2020:
                   case VMTypes.X25519KeyAgreementKey2020:
                     // Always produce publicKeyMultibase regardless of encoding hint, to match spec.
-                    pk.publicKeyMultibase = toMultibase(currentEvent.value, multicodecPrefixes[pk.type])
+                    pk.publicKeyMultibase = toMultibase(event.value, multicodecPrefixes[pk.type])
                     break
                   case VMTypes.Multikey:
                     // On-chain value already includes the multicodec prefix; just base58btc-encode.
-                    pk.publicKeyMultibase = toMultibase(currentEvent.value)
+                    pk.publicKeyMultibase = toMultibase(event.value)
                     break
                   default:
                     // Unknown key types: honor the encoding hint for legacy compat.
@@ -285,16 +294,19 @@ export class EthrDidResolver {
                       case null:
                       case undefined:
                       case 'hex':
-                        pk.publicKeyHex = strip0x(currentEvent.value)
+                        // noinspection JSDeprecatedSymbols
+                        pk.publicKeyHex = strip0x(event.value)
                         break
                       case 'base64':
-                        pk.publicKeyBase64 = encodeBase64(currentEvent.value)
+                        // noinspection JSDeprecatedSymbols
+                        pk.publicKeyBase64 = encodeBase64(event.value)
                         break
                       case 'base58':
-                        pk.publicKeyBase58 = encodeBase58(currentEvent.value)
+                        // noinspection JSDeprecatedSymbols
+                        pk.publicKeyBase58 = encodeBase58(event.value)
                         break
                       default:
-                        pk.value = strip0x(currentEvent.value)
+                        pk.value = strip0x(event.value)
                     }
                 }
                 pks[eventIndex] = pk
@@ -306,57 +318,45 @@ export class EthrDidResolver {
                 } else {
                   signingRefs[eventIndex] = pk.id
                 }
-                break
+              } else {
+                // revocation
+                delete pks[eventIndex]
+                delete auth[eventIndex]
+                delete signingRefs[eventIndex]
+                delete keyAgreementRefs[eventIndex]
               }
-              case 'svc': {
-                serviceCount++
-                let encodedService: string | null = null
+              break
+            }
+            case 'svc': {
+              let encodedService: string | null = null
+              try {
+                encodedService = toUtf8String(event.value)
+              } catch {
+                // value is not valid UTF-8; skip this service — non-DID use of registry
+              }
+              if (encodedService !== null) {
+                let endpoint
                 try {
-                  encodedService = toUtf8String(currentEvent.value)
+                  endpoint = JSON.parse(encodedService)
                 } catch {
-                  // value is not valid UTF-8; skip this service — non-DID use of registry
+                  endpoint = encodedService
                 }
-                if (encodedService !== null) {
-                  try {
-                    endpoint = JSON.parse(encodedService)
-                  } catch {
-                    endpoint = encodedService
-                  }
+                if (event.validTo >= now) {
+                  // addition
                   services[eventIndex] = {
                     id: `${did}#service-${serviceCount}`,
                     type: algorithm,
                     serviceEndpoint: endpoint,
                   }
+                } else {
+                  // revocation
+                  delete services[eventIndex]
                 }
-                break
               }
+              break
             }
           }
         }
-      } else if (event._eventName === eventNames.DIDOwnerChanged) {
-        const currentEvent = event as DIDOwnerChanged
-        controller = currentEvent.owner
-        if (currentEvent.owner === nullAddress) {
-          deactivated = true
-          break
-        }
-      } else {
-        if (
-          event._eventName === eventNames.DIDDelegateChanged ||
-          (event._eventName === eventNames.DIDAttributeChanged &&
-            (event as DIDAttributeChanged).name.match(/^did\/pub\//))
-        ) {
-          delegateCount++
-        } else if (
-          event._eventName === eventNames.DIDAttributeChanged &&
-          (event as DIDAttributeChanged).name.match(/^did\/svc\//)
-        ) {
-          serviceCount++
-        }
-        delete auth[eventIndex]
-        delete signingRefs[eventIndex]
-        delete pks[eventIndex]
-        delete services[eventIndex]
       }
     }
 
@@ -374,7 +374,7 @@ export class EthrDidResolver {
         id: `${did}#controllerKey`,
         type: VMTypes.EcdsaSecp256k1VerificationKey2019,
         controller: did,
-        publicKeyJwk: compressedSecp256k1ToJwk(controllerKey),
+        publicKeyJwk: secp256k1ToJwk(controllerKey),
       })
       authentication.push(`${did}#controllerKey`)
       assertionMethod.push(`${did}#controllerKey`)


### PR DESCRIPTION
fix: revocation of keyAgreement keys was leaving dangling references in the `keyAgreement` relationship.

Now, more type safety and hopefully easier to understand code.