### PR TITLE
feat: add support for versionTime to resolve historical DID documents

### DIFF
--- a/src/__tests__/resolver.versioning.test.ts
+++ b/src/__tests__/resolver.versioning.test.ts
@@ -218,6 +218,174 @@ describe('versioning', () => {
     })
   })
 
+  it('can resolve did with versionTime before delegate creation excludes delegate', async () => {
+    expect.assertions(1)
+    const delegate = '0xde1E9a7e00000000000000000000000000000001'
+    const { address, shortDID: identifier, signer } = await randomAccount(provider)
+    const validitySeconds = 100_000
+    await new EthrDidController(identifier, registryContract, signer).addDelegate('sigAuth', delegate, validitySeconds)
+    const block = await provider.getBlock('latest')
+    const blockTs = block!.timestamp
+    // versionTime set to 1 second before the delegate was added
+    const before = blockTs - 1
+
+    const result = await didResolver.resolve(`${identifier}?versionTime=${before}`)
+    expect(result).toEqual({
+      didDocumentMetadata: { nextVersionId: expect.anything(), nextUpdate: expect.anything() },
+      didResolutionMetadata: expect.anything(),
+      didDocument: {
+        '@context': expect.anything(),
+        id: identifier,
+        verificationMethod: [
+          {
+            id: `${identifier}#controller`,
+            type: 'EcdsaSecp256k1RecoveryMethod2020',
+            controller: identifier,
+            blockchainAccountId: `eip155:1337:${address}`,
+          },
+        ],
+        authentication: [`${identifier}#controller`],
+        assertionMethod: [`${identifier}#controller`],
+      },
+    })
+  })
+
+  it('can resolve did with versionTime before delegate creation as ISO 8601 string excludes delegate', async () => {
+    expect.assertions(1)
+    const delegate = '0xde1E9a7e00000000000000000000000000000001'
+    const { address, shortDID: identifier, signer } = await randomAccount(provider)
+    const validitySeconds = 100_000
+    await new EthrDidController(identifier, registryContract, signer).addDelegate('sigAuth', delegate, validitySeconds)
+    const block = await provider.getBlock('latest')
+    const blockTs = block!.timestamp
+    const before = new Date((blockTs - 1) * 1000).toISOString().replace('.000Z', 'Z')
+
+    const result = await didResolver.resolve(`${identifier}?versionTime=${before}`)
+    expect(result).toEqual({
+      didDocumentMetadata: { nextVersionId: expect.anything(), nextUpdate: expect.anything() },
+      didResolutionMetadata: expect.anything(),
+      didDocument: {
+        '@context': expect.anything(),
+        id: identifier,
+        verificationMethod: [
+          {
+            id: `${identifier}#controller`,
+            type: 'EcdsaSecp256k1RecoveryMethod2020',
+            controller: identifier,
+            blockchainAccountId: `eip155:1337:${address}`,
+          },
+        ],
+        authentication: [`${identifier}#controller`],
+        assertionMethod: [`${identifier}#controller`],
+      },
+    })
+  })
+
+  it('can resolve did with versionTime at block timestamp includes delegate', async () => {
+    expect.assertions(1)
+    const delegate = '0xde1E9a7e00000000000000000000000000000001'
+    const { address, shortDID: identifier, signer } = await randomAccount(provider)
+    const validitySeconds = 100_000
+    await new EthrDidController(identifier, registryContract, signer).addDelegate('sigAuth', delegate, validitySeconds)
+    const block = await provider.getBlock('latest')
+    const blockTs = block!.timestamp
+
+    const result = await didResolver.resolve(`${identifier}?versionTime=${blockTs}`)
+    expect(result).toEqual({
+      didDocumentMetadata: { versionId: expect.anything(), updated: expect.anything() },
+      didResolutionMetadata: expect.anything(),
+      didDocument: {
+        '@context': expect.anything(),
+        id: identifier,
+        verificationMethod: [
+          {
+            id: `${identifier}#controller`,
+            type: 'EcdsaSecp256k1RecoveryMethod2020',
+            controller: identifier,
+            blockchainAccountId: `eip155:1337:${address}`,
+          },
+          {
+            id: `${identifier}#delegate-1`,
+            type: 'EcdsaSecp256k1RecoveryMethod2020',
+            controller: identifier,
+            blockchainAccountId: `eip155:1337:${delegate}`,
+          },
+        ],
+        authentication: [`${identifier}#controller`, `${identifier}#delegate-1`],
+        assertionMethod: [`${identifier}#controller`, `${identifier}#delegate-1`],
+      },
+    })
+  })
+
+  it('can resolve did with versionTime after delegate expiry excludes the delegate', async () => {
+    expect.assertions(1)
+    const delegate = '0xde1E9a7e00000000000000000000000000000001'
+    const { address, shortDID: identifier, signer } = await randomAccount(provider)
+    const validitySeconds = 100_000
+    await new EthrDidController(identifier, registryContract, signer).addDelegate('sigAuth', delegate, validitySeconds)
+    const block = await provider.getBlock('latest')
+    const blockTs = block!.timestamp
+    // validTo = blockTs + validitySeconds, so afterExpiry is past validTo
+    const afterExpiry = blockTs + validitySeconds + 1
+
+    const result = await didResolver.resolve(`${identifier}?versionTime=${afterExpiry}`)
+    expect(result).toEqual({
+      didDocumentMetadata: { versionId: expect.anything(), updated: expect.anything() },
+      didResolutionMetadata: expect.anything(),
+      didDocument: {
+        '@context': expect.anything(),
+        id: identifier,
+        verificationMethod: [
+          {
+            id: `${identifier}#controller`,
+            type: 'EcdsaSecp256k1RecoveryMethod2020',
+            controller: identifier,
+            blockchainAccountId: `eip155:1337:${address}`,
+          },
+        ],
+        authentication: [`${identifier}#controller`],
+        assertionMethod: [`${identifier}#controller`],
+      },
+    })
+  })
+
+  it('can resolve did with versionTime as ISO 8601 string', async () => {
+    expect.assertions(1)
+    const delegate = '0xde1E9a7e00000000000000000000000000000001'
+    const { address, shortDID: identifier, signer } = await randomAccount(provider)
+    const validitySeconds = 100_000
+    await new EthrDidController(identifier, registryContract, signer).addDelegate('sigAuth', delegate, validitySeconds)
+    const block = await provider.getBlock('latest')
+    const blockTs = block!.timestamp
+    const blockTsIso = new Date(blockTs * 1000).toISOString().replace('.000Z', 'Z')
+
+    const result = await didResolver.resolve(`${identifier}?versionTime=${blockTsIso}`)
+    expect(result).toEqual({
+      didDocumentMetadata: { versionId: expect.anything(), updated: expect.anything() },
+      didResolutionMetadata: expect.anything(),
+      didDocument: {
+        '@context': expect.anything(),
+        id: identifier,
+        verificationMethod: [
+          {
+            id: `${identifier}#controller`,
+            type: 'EcdsaSecp256k1RecoveryMethod2020',
+            controller: identifier,
+            blockchainAccountId: `eip155:1337:${address}`,
+          },
+          {
+            id: `${identifier}#delegate-1`,
+            type: 'EcdsaSecp256k1RecoveryMethod2020',
+            controller: identifier,
+            blockchainAccountId: `eip155:1337:${delegate}`,
+          },
+        ],
+        authentication: [`${identifier}#controller`, `${identifier}#delegate-1`],
+        assertionMethod: [`${identifier}#controller`, `${identifier}#delegate-1`],
+      },
+    })
+  })
+
   it('can resolve did with versionId before an attribute expiration', async () => {
     expect.assertions(3)
     const delegate = '0xde1E9a7e00000000000000000000000000000001'

--- a/src/__tests__/resolver.versioning.test.ts
+++ b/src/__tests__/resolver.versioning.test.ts
@@ -434,4 +434,15 @@ describe('versioning', () => {
       },
     })
   })
+
+  it('returns invalidOptions error when both versionId and versionTime are set', async () => {
+    expect.assertions(1)
+    const { shortDID: identifier } = await randomAccount(provider)
+    const result = await didResolver.resolve(`${identifier}?versionId=1&versionTime=1000000000`)
+    expect(result).toEqual({
+      didResolutionMetadata: { error: 'invalidOptions', message: 'Conflicting options: versionId and versionTime cannot both be set.' },
+      didDocumentMetadata: {},
+      didDocument: null,
+    })
+  })
 })

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -239,6 +239,11 @@ export const Errors = {
    * The resolver does not support the 'accept' format requested with `DIDResolutionOptions`
    */
   unsupportedFormat: 'unsupportedFormat',
+
+  /**
+   * The DID URL contains conflicting options, e.g. both versionId and versionTime.
+   */
+  invalidOptions: 'invalidOptions',
 } as const
 export type Errors = (typeof Errors)[keyof typeof Errors]
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -461,9 +461,20 @@ export class EthrDidResolver {
       const versionIdStr = qParams.get('versionId')
       const versionTimeStr = qParams.get('versionTime')
 
+      if (versionIdStr && versionTimeStr) {
+        return {
+          didResolutionMetadata: {
+            error: Errors.invalidOptions,
+            message: 'Conflicting options: versionId and versionTime cannot both be set.',
+          },
+          didDocumentMetadata: {},
+          didDocument: null,
+        }
+      }
+
       if (versionIdStr) {
         blockTag = versionIdStr
-        const parsedBlockTag = Number.parseInt(blockTag as string)
+        const parsedBlockTag = Number.parseInt(blockTag as string, 10)
         if (!Number.isNaN(parsedBlockTag)) {
           blockTag = parsedBlockTag
         } else {
@@ -471,9 +482,9 @@ export class EthrDidResolver {
         }
       }
 
-      if (!versionIdStr && versionTimeStr) {
+      if (versionTimeStr) {
         if (/^\d+$/.test(versionTimeStr)) {
-          versionTimeTimestamp = parseInt(versionTimeStr)
+          versionTimeTimestamp = parseInt(versionTimeStr, 10)
         } else {
           versionTimeTimestamp = Math.floor(new Date(versionTimeStr).getTime() / 1000)
         }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -224,10 +224,15 @@ export class EthrDidResolver {
           nextVersionId = event.blockNumber
         }
         continue
-      } else {
-        if (versionId < event.blockNumber) {
-          versionId = event.blockNumber
+      }
+      if (event.blockTimestamp > now) {
+        if (nextVersionId > event.blockNumber) {
+          nextVersionId = event.blockNumber
         }
+        continue
+      }
+      if (versionId < event.blockNumber) {
+        versionId = event.blockNumber
       }
       if (event.eventType === 'DIDOwnerChanged') {
         controller = event.owner
@@ -450,14 +455,31 @@ export class EthrDidResolver {
     const id = fullId[2]
     const networkId = !fullId[1] ? 'mainnet' : fullId[1].slice(0, -1)
     let blockTag: string | number = options.blockTag || 'latest'
+    let versionTimeTimestamp: number | undefined
     if (typeof parsed.query === 'string') {
       const qParams = new URLSearchParams(parsed.query)
-      blockTag = qParams.get('versionId') ?? blockTag
-      const parsedBlockTag = Number.parseInt(blockTag as string)
-      if (!Number.isNaN(parsedBlockTag)) {
-        blockTag = parsedBlockTag
-      } else {
-        blockTag = 'latest'
+      const versionIdStr = qParams.get('versionId')
+      const versionTimeStr = qParams.get('versionTime')
+
+      if (versionIdStr) {
+        blockTag = versionIdStr
+        const parsedBlockTag = Number.parseInt(blockTag as string)
+        if (!Number.isNaN(parsedBlockTag)) {
+          blockTag = parsedBlockTag
+        } else {
+          blockTag = 'latest'
+        }
+      }
+
+      if (!versionIdStr && versionTimeStr) {
+        if (/^\d+$/.test(versionTimeStr)) {
+          versionTimeTimestamp = parseInt(versionTimeStr)
+        } else {
+          versionTimeTimestamp = Math.floor(new Date(versionTimeStr).getTime() / 1000)
+        }
+        if (isNaN(versionTimeTimestamp)) {
+          versionTimeTimestamp = undefined
+        }
       }
     }
 
@@ -475,12 +497,15 @@ export class EthrDidResolver {
     let now: number = Math.floor(new Date().getTime() / 1000)
 
     try {
-      if (typeof blockTag === 'number') {
+      if (versionTimeTimestamp !== undefined) {
+        now = versionTimeTimestamp
+      } else if (typeof blockTag === 'number') {
         const block = await this.getBlockMetadata(blockTag, networkId)
         now = block.timestamp
       }
 
       const { address, history, controllerKey, chainId } = await this.changeLog(id, networkId, 'latest')
+
       const { didDocument, deactivated, versionId, nextVersionId } = this.wrapDidDocument(
         did,
         address,
@@ -519,7 +544,7 @@ export class EthrDidResolver {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       const message: string = e?.message ?? e?.toString() ?? 'unknown error'
-      const isHistoricalQuery = typeof blockTag === 'number'
+      const isHistoricalQuery = typeof blockTag === 'number' || versionTimeTimestamp !== undefined
       // Errors that indicate the node lacks historical state (non-archive node)
       const isArchiveError =
         message.includes('missing trie node') ||
@@ -542,7 +567,7 @@ export class EthrDidResolver {
       let hint = ''
       if (isArchiveError || (isHistoricalQuery && isServerError)) {
         hint =
-          ' The RPC node does not have the requested historical state. Use an archive node to resolve historical DID versions (versionId queries).'
+          ' The RPC node does not have the requested historical state. Use an archive node to resolve historical DID versions (versionId/versionTime queries).'
       } else if (isRpcError) {
         hint = ' Ensure the RPC endpoint is reachable.'
       }


### PR DESCRIPTION
Add support for `?versionTime=<ISO DateTime or Unix timestamp>` DID resolution.

It works similarly to `versionId`:
* events that occurred after the versionTime don't get processed when building the DID document.
* events that occurred at or before the versionTime get processed.

Additionally, versionTime can be used to resolve hypothetical future DID states where some delegates or service endpoints might have expired.