### PR TITLE
fix: replace `unsupportedFormat` error with `representationNotSupported`

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -32,7 +32,7 @@ describe('error handling', () => {
       didDocument: null,
       didDocumentMetadata: {},
       didResolutionMetadata: {
-        error: 'unknownNetwork',
+        error: 'internalError',
         message: 'The DID resolver does not have a configuration for network: zrx',
       },
     })
@@ -49,7 +49,7 @@ describe('error handling', () => {
       didDocument: null,
       didDocumentMetadata: {},
       didResolutionMetadata: {
-        error: 'unsupportedFormat',
+        error: 'representationNotSupported',
         message: `The DID resolver does not support the requested 'accept' format: ${accept}`,
       },
     })

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -233,12 +233,12 @@ export const Errors = {
   /**
    * The resolver is misconfigured or is being asked to resolve a `DID` anchored on an unknown network
    */
-  unknownNetwork: 'unknownNetwork',
+  unknownNetwork: 'internalError',
 
   /**
    * The resolver does not support the 'accept' format requested with `DIDResolutionOptions`
    */
-  unsupportedFormat: 'unsupportedFormat',
+  representationNotSupported: 'representationNotSupported',
 
   /**
    * The DID URL contains conflicting options, e.g. both versionId and versionTime.

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -433,7 +433,7 @@ export class EthrDidResolver {
     } else {
       return {
         didResolutionMetadata: {
-          error: Errors.unsupportedFormat,
+          error: Errors.representationNotSupported,
           message: `The DID resolver does not support the requested 'accept' format: ${options.accept}`,
         },
         didDocumentMetadata: {},


### PR DESCRIPTION
Also, the non-standard `unknownNetwork` error now maps to `internalError` to better align with the [DID resolution spec](https://w3c.github.io/did-resolution/#errors)

BREAKING CHANGE: the exported API is being updated. `Errors.unsupportedFormat` is now `Errors.representationNotSupported`