### PR TITLE
feat: infer network config from known deployments

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -88,4 +88,45 @@ describe('configuration', () => {
       configureResolverWithNetworks({ networks: [{ web3: '0xbad' }] })
     }).toThrow('invalid_config: No web3 provider could be determined for network')
   })
+
+  it('known network by name + rpcUrl inherits registry and registers both name and hex key', () => {
+    const contracts = configureResolverWithNetworks({
+      networks: [{ name: 'mainnet', rpcUrl: 'http://localhost:8545' }],
+    })
+    expect(contracts['mainnet']).toBeDefined()
+    expect(contracts['0x1']).toBeDefined()
+  })
+
+  it('known network by chainId + rpcUrl auto-registers deployment name', () => {
+    const contracts = configureResolverWithNetworks({
+      networks: [{ chainId: 1, rpcUrl: 'http://localhost:8545' }],
+    })
+    expect(contracts['mainnet']).toBeDefined()
+    expect(contracts['0x1']).toBeDefined()
+  })
+
+  it('known network by chainId + rpcUrl auto-registers deployment name for non-mainnet', () => {
+    const contracts = configureResolverWithNetworks({
+      networks: [{ chainId: 1313161554, rpcUrl: 'http://localhost:8545' }],
+    })
+    expect(contracts['aurora']).toBeDefined()
+    expect(contracts['0x4e454152']).toBeDefined()
+  })
+
+  it('override deployment registry address', () => {
+    const contracts = configureResolverWithNetworks({
+      networks: [{ name: 'mainnet', rpcUrl: 'http://localhost:8545', registry: '0x9af37603e98e0dc2b855be647c39abe984fc2445' }],
+    })
+    expect(contracts['mainnet']).toBeDefined()
+    expect(contracts['0x1']).toBeDefined()
+    expect(contracts['mainnet'].target).toBe('0x9af37603e98e0dc2b855be647c39abe984fc2445')
+  })
+
+  it('override legacyNonce in config', () => {
+    const contracts = configureResolverWithNetworks({
+      networks: [{ name: 'mainnet', rpcUrl: 'http://localhost:8545', legacyNonce: false }],
+    })
+    expect(contracts['mainnet']).toBeDefined()
+    expect(contracts['0x1']).toBeDefined()
+  })
 })

--- a/src/__tests__/networks.integration.test.ts
+++ b/src/__tests__/networks.integration.test.ts
@@ -227,9 +227,7 @@ describe('ethrResolver (alt-chains)', () => {
         networks: [
           {
             name: 'aurora',
-            chainId: 1313161554,
             rpcUrl: 'https://mainnet.aurora.dev',
-            registry: '0x63eD58B671EeD12Bc1652845ba5b2CDfBff198e0',
           },
         ],
       })

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -107,10 +107,12 @@ function configureNetwork(
   cacheOptions?: WrapProviderOptions
 ): ConfiguredNetworks {
   const networks: ConfiguredNetworks = {}
-  const chainId = net.chainId || deployments.find((d) => matchesDeployment(d, net))?.chainId
+  const matchingDeployment = deployments.find((d) => matchesDeployment(d, net))
+  const chainId = net.chainId || matchingDeployment?.chainId
   if (chainId) {
-    if (net.name) {
-      networks[net.name] = getContractForNetwork(net, store, cacheOptions)
+    const netName = net.name || matchingDeployment?.name
+    if (netName) {
+      networks[netName] = getContractForNetwork(net, store, cacheOptions)
     }
     const id = typeof chainId === 'bigint' || typeof chainId === 'number' ? `0x${chainId.toString(16)}` : chainId
     networks[id] = getContractForNetwork(net, store, cacheOptions)

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -18,6 +18,7 @@ import {
   TransactionReceipt,
   zeroPadValue,
 } from 'ethers'
+import { deployments } from './config/deployments.js'
 import { getContractForNetwork } from './configuration.js'
 import { address, interpretIdentifier, MESSAGE_PREFIX, MetaSignature, stringToBytes32 } from './helpers.js'
 
@@ -55,12 +56,20 @@ export class EthrDidController {
     provider?: Provider,
     rpcUrl?: string,
     registry?: string,
-    legacyNonce = true
+    legacyNonce?: boolean
   ) {
-    this.legacyNonce = legacyNonce
-    // initialize identifier
     const { address, publicKey, network } = interpretIdentifier(identifier)
     const net = network || chainNameOrId
+    const matchedDeployment = deployments.find((d) => {
+      if (d.name === net || d.description === net) return true
+      if (net == null) return false
+      try {
+        return BigInt(d.chainId) === BigInt(net)
+      } catch {
+        return false
+      }
+    })
+    this.legacyNonce = legacyNonce ?? matchedDeployment?.legacyNonce ?? true
     // initialize contract connection
     if (contract) {
       this.contract = contract


### PR DESCRIPTION
fixes #279

A config for `mainnet` automatically configures `0x1` and vice-versa. Same for other named networks.