### PR TITLE
fix: Handle invalid secp256k1 keys

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -115,7 +115,9 @@ describe('configuration', () => {
 
   it('override deployment registry address', () => {
     const contracts = configureResolverWithNetworks({
-      networks: [{ name: 'mainnet', rpcUrl: 'http://localhost:8545', registry: '0x9af37603e98e0dc2b855be647c39abe984fc2445' }],
+      networks: [
+        { name: 'mainnet', rpcUrl: 'http://localhost:8545', registry: '0x9af37603e98e0dc2b855be647c39abe984fc2445' },
+      ],
     })
     expect(contracts['mainnet']).toBeDefined()
     expect(contracts['0x1']).toBeDefined()

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -24,6 +24,21 @@ describe('error handling', () => {
     })
   })
 
+  // 33-byte hex (passes the identifier regex) but x=5 is not on the secp256k1 curve
+  const OFF_CURVE_KEY = '0x020000000000000000000000000000000000000000000000000000000000000005'
+
+  it('rejects DID whose compressed secp256k1 key is not on the curve', async () => {
+    expect.assertions(1)
+    await expect(didResolver.resolve(`did:ethr:${OFF_CURVE_KEY}`)).resolves.toEqual({
+      didDocument: null,
+      didDocumentMetadata: {},
+      didResolutionMetadata: {
+        error: 'invalidDid',
+        message: `Not a valid did:ethr: ${OFF_CURVE_KEY}`,
+      },
+    })
+  })
+
   it('rejects resolution on unconfigured network', async () => {
     expect.assertions(1)
     await expect(

--- a/src/__tests__/networks.integration.test.ts
+++ b/src/__tests__/networks.integration.test.ts
@@ -267,4 +267,20 @@ describe('ethrResolver (alt-chains)', () => {
       })
     })
   })
+
+  describe('polygon', () => {
+    it('gracefully skips invalid 96-byte secp256k1 key on polygon', async () => {
+      const did = 'did:ethr:polygon:0x4a21b852ea26d0d2784aa85db156cd6310619c48'
+      const resolver = new Resolver(
+        getResolver({ networks: [{ name: 'polygon', rpcUrl: 'https://polygon.gateway.tenderly.co' }] })
+      )
+      const result = await resolver.resolve(did)
+      // Expect a valid document — the invalid Secp256k1 key is skipped, but the
+      // base DID document (controller verification method) is still produced.
+      expect(result.didDocument).not.toBeNull()
+      expect(result.didResolutionMetadata.error).toBeUndefined()
+      expect(result.didDocument!.verificationMethod).toHaveLength(1)
+      expect(result.didDocument!.verificationMethod?.[0].id).toBe(`${did}#controller`)
+    })
+  })
 })

--- a/src/__tests__/resolver.versioning.test.ts
+++ b/src/__tests__/resolver.versioning.test.ts
@@ -440,7 +440,10 @@ describe('versioning', () => {
     const { shortDID: identifier } = await randomAccount(provider)
     const result = await didResolver.resolve(`${identifier}?versionId=1&versionTime=1000000000`)
     expect(result).toEqual({
-      didResolutionMetadata: { error: 'invalidOptions', message: 'Conflicting options: versionId and versionTime cannot both be set.' },
+      didResolutionMetadata: {
+        error: 'invalidOptions',
+        message: 'Conflicting options: versionId and versionTime cannot both be set.',
+      },
       didDocumentMetadata: {},
       didDocument: null,
     })

--- a/src/__tests__/wrap-did-document.test.ts
+++ b/src/__tests__/wrap-did-document.test.ts
@@ -79,4 +79,25 @@ describe('wrapDidDocument', () => {
     )
     expect(addedDoc.verificationMethod).toHaveLength(2) // controller + delegate
   })
+
+  it('4.4 drops an invalid controller public key instead of crashing', () => {
+    // 33-byte hex (would pass the identifier regex) but x=5 is not on the secp256k1 curve.
+    // resolve() rejects such identifiers up front; wrapping defensively drops the key.
+    const offCurveKey = '0x020000000000000000000000000000000000000000000000000000000000000005'
+    const { didDocument, deactivated } = resolver.wrapDidDocument(
+      DID,
+      ADDRESS,
+      offCurveKey,
+      [],
+      CHAIN_ID,
+      'latest',
+      NOW
+    )
+    // No #controllerKey verification method/references - only the base controller remains.
+    expect(deactivated).toBe(false)
+    expect(didDocument.verificationMethod).toHaveLength(1)
+    expect(didDocument.verificationMethod?.[0].id).toBe(`${DID}#controller`)
+    expect(didDocument.authentication).toEqual([`${DID}#controller`])
+    expect(didDocument.assertionMethod).toEqual([`${DID}#controller`])
+  })
 })

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -283,13 +283,17 @@ export function toMultibase(hexValue: string, prefix?: Uint8Array): string {
  * Decompresses a 33-byte secp256k1 public key (hex, with or without 0x prefix) and
  * returns a JWK object suitable for use as `publicKeyJwk` in a DID document.
  */
-export function secp256k1ToJwk(hex: string): JsonWebKey {
-  const uncompressed = SigningKey.computePublicKey(hex.startsWith('0x') ? hex : `0x${hex}`, false)
-  // uncompressed is 0x04 || x (32 bytes) || y (32 bytes)
-  const raw = getBytes(uncompressed)
-  const toBase64url = (bytes: Uint8Array) =>
-    encodeBase64(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
-  const x = toBase64url(raw.slice(1, 33))
-  const y = toBase64url(raw.slice(33, 65))
-  return { kty: 'EC', crv: 'secp256k1', x, y }
+export function secp256k1ToJwk(hex: string): JsonWebKey | null {
+  try {
+    const uncompressed = SigningKey.computePublicKey(hex.startsWith('0x') ? hex : `0x${hex}`, false)
+    // uncompressed is 0x04 || x (32 bytes) || y (32 bytes)
+    const raw = getBytes(uncompressed)
+    const toBase64url = (bytes: Uint8Array) =>
+      encodeBase64(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+    const x = toBase64url(raw.slice(1, 33))
+    const y = toBase64url(raw.slice(33, 65))
+    return { kty: 'EC', crv: 'secp256k1', x, y }
+  } catch {
+    return null
+  }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -280,8 +280,8 @@ export function toMultibase(hexValue: string, prefix?: Uint8Array): string {
 }
 
 /**
- * Decompresses a 33-byte secp256k1 public key (hex, with or without 0x prefix) and
- * returns a JWK object suitable for use as `publicKeyJwk` in a DID document.
+ * Decompresses a 33-byte or 65-byte secp256k1 public key (hex, with or without 0x prefix) and
+ * returns a JWK object suitable for use as `publicKeyJwk` in a DID document, or null if the input is invalid.
  */
 export function secp256k1ToJwk(hex: string): JsonWebKey | null {
   try {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -291,7 +291,7 @@ export class EthrDidResolver {
                   controller: did,
                 }
                 switch (pk.type) {
-                  case VMTypes.EcdsaSecp256k1VerificationKey2019:
+                  case VMTypes.EcdsaSecp256k1VerificationKey2019: {
                     // Spec mandates publicKeyJwk for Secp256k1 attribute keys regardless of encoding hint.
                     const jwk = secp256k1ToJwk(event.value)
                     if (jwk) {
@@ -300,7 +300,7 @@ export class EthrDidResolver {
                     } else {
                       continue
                     }
-                    break
+                  }
                   case VMTypes.Ed25519VerificationKey2020:
                   case VMTypes.X25519KeyAgreementKey2020:
                     // Always produce publicKeyMultibase regardless of encoding hint, to match spec.

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -402,10 +402,9 @@ export class EthrDidResolver {
         })
         authentication.push(`${did}#controllerKey`)
         assertionMethod.push(`${did}#controllerKey`)
-      } else {
-        // TODO: should be a notFound or invalidDID error
       }
-
+      // Invalid keys are rejected in resolve() (invalidDid) before this point, so this
+      // guard is only defensive against direct wrapDidDocument calls - drop the key.
     }
 
     const didDocument: DIDDocument = {
@@ -465,6 +464,19 @@ export class EthrDidResolver {
       }
     }
     const id = fullId[2]
+    // A 33-byte hex identifier denotes a compressed secp256k1 public key. The regex only
+    // checks its shape, so reject identifiers whose key is not on the curve here, before
+    // any network work (interpretIdentifier would otherwise throw an internal crypto error).
+    if (id.length > 42 && !secp256k1ToJwk(id)) {
+      return {
+        didResolutionMetadata: {
+          error: Errors.invalidDid,
+          message: `Not a valid did:ethr: ${parsed.id}`,
+        },
+        didDocumentMetadata: {},
+        didDocument: null,
+      }
+    }
     const networkId = !fullId[1] ? 'mainnet' : fullId[1].slice(0, -1)
     let blockTag: string | number = options.blockTag || 'latest'
     let versionTimeTimestamp: number | undefined

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -293,7 +293,13 @@ export class EthrDidResolver {
                 switch (pk.type) {
                   case VMTypes.EcdsaSecp256k1VerificationKey2019:
                     // Spec mandates publicKeyJwk for Secp256k1 attribute keys regardless of encoding hint.
-                    pk.publicKeyJwk = secp256k1ToJwk(event.value)
+                    const jwk = secp256k1ToJwk(event.value)
+                    if (jwk) {
+                      pk.publicKeyJwk = jwk
+                      break
+                    } else {
+                      continue
+                    }
                     break
                   case VMTypes.Ed25519VerificationKey2020:
                   case VMTypes.X25519KeyAgreementKey2020:
@@ -386,14 +392,20 @@ export class EthrDidResolver {
     ]
 
     if (controllerKey && controller == address) {
-      publicKeys.push({
-        id: `${did}#controllerKey`,
-        type: VMTypes.EcdsaSecp256k1VerificationKey2019,
-        controller: did,
-        publicKeyJwk: secp256k1ToJwk(controllerKey),
-      })
-      authentication.push(`${did}#controllerKey`)
-      assertionMethod.push(`${did}#controllerKey`)
+      const publicKeyJwk = secp256k1ToJwk(controllerKey)
+      if (publicKeyJwk) {
+        publicKeys.push({
+          id: `${did}#controllerKey`,
+          type: VMTypes.EcdsaSecp256k1VerificationKey2019,
+          controller: did,
+          publicKeyJwk,
+        })
+        authentication.push(`${did}#controllerKey`)
+        assertionMethod.push(`${did}#controllerKey`)
+      } else {
+        // TODO: should be a notFound or invalidDID error
+      }
+
     }
 
     const didDocument: DIDDocument = {


### PR DESCRIPTION
This fix covers 2 corner cases: 
* Public key DIDs whose keys are invalid => now returning `invalidDID` error instead of crashing
* DIDAttributeChanged events containing invalid key material => these keys get ignored instead of failing resolution